### PR TITLE
Fix proxy webhook install

### DIFF
--- a/dash/backend/scripts/proxy-webhook/auto-setup.sh
+++ b/dash/backend/scripts/proxy-webhook/auto-setup.sh
@@ -58,8 +58,14 @@ cp initialize_proxy.yaml init.yaml
 cp openssl.cnf ssl.cnf
 
 # Change the namespace in the initialize file and openssl configuration
-sed -I '' -e 's/m9sweeper-system/'$namespace'/g' init.yaml
-sed -I '' -e 's/m9sweeper-system/'$namespace'/g' ssl.cnf
+platform=$(uname)
+if [[ "$platform" != 'Linux' ]]; then
+    sed -i "s/m9sweeper-system/$namespace/g" init.yaml
+    sed -i "s/m9sweeper-system/$namespace/g" ssl.cnf
+else
+    sed -i '' -e "s/m9sweeper-system/$namespace/g" init.yaml
+    sed -i '' -e "s/m9sweeper-system/$namespace/g" ssl.cnf
+fi
 
 # Create a service account, role, rolebinding, and deployment to create the nginx reverse proxy. These will be deleted at the end.
 kubectl -n $namespace create -f init.yaml;
@@ -67,7 +73,7 @@ kubectl -n $namespace create -f init.yaml;
 # Wait 30 seconds for pod to be running - sometimes the first run pulling the image takes a bit.
 
 echo "Waiting for init pod to be created..."
-sleep 30; 
+sleep 30;
 
 # Delete the existing validating webhook configuration.
 kubectl -n $namespace delete validatingwebhookconfiguration m9sweeper-webhook


### PR DESCRIPTION
Fixes an issue with sed in the auto-setup.sh script. SED does not recognize `-I` as a valid argument on the linux versions and it also does not work with the extra `''` in the command. This fixes this by checking if the OS is linux or not and running a different version of the command on linux vs maxOS machines to account for the differences.

Also adds `set -e` to allow the script to return a error code if a portion fails so that when used in pipelines it allows a stage to fail upon failure of the script.