### PR TITLE
Update falco output URL and baseUrl default

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/falco/falco-dialog/falco-dialog.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-dialog/falco-dialog.component.html
@@ -32,7 +32,7 @@ helm upgrade --install falco falcosecurity/falco \
   --set falco.tty=true \
   --set falco.json_output=true \
   --set falco.http_output.enabled=true \
-  --set-string falco.http_output.url='http://falcosidekick:2801/' \
+  --set-string falco.http_output.url='http://falco-falcosidekick:2801/' \
   --set falcosidekick.enabled=true \
   --set-string falcosidekick.config.webhook.address='{{backendUrl}}/api/falco/{{clusterId}}/create/?key={{apiKey}}' \
   --set falcosidekick.config.webhook.checkcert=true \

--- a/manifests/charts/m9sweeper/values.yaml
+++ b/manifests/charts/m9sweeper/values.yaml
@@ -29,7 +29,7 @@ global:
   # Provide a secret string that will be used to sign JWT tokens, it is highly recommended that you set this to your own secret
   jwtSecret: "this-is-not-secret"
   # This URL will be used in email templates to reference a http link to Dash
-  baseUrl: "http://m9sweeper-dash:3000"
+  baseUrl: "http://m9sweeper-dash.m9sweeper-system.svc:3000"
   # Provide a secret string that will be set as the trawler service account's API key.
   # It will also be passed to trawler so that it can auth with Dash. You will not need it
   # after the initial installation as it will be loaded into the DB.


### PR DESCRIPTION
Updates the command shown to users to install m9sweeper to fix the http output URL. Also changes the baseUrl in the main chart to include the full namespace so falco can access it since its installed in a different namespace if not using an ingress.