### PR TITLE
Add GitHub and Kubernetes container registries to defaults

### DIFF
--- a/manifests/charts/dash/values.yaml
+++ b/manifests/charts/dash/values.yaml
@@ -63,6 +63,12 @@ init:
         aliases:
           - index.docker.io
         login_required: false
+      - name: "GitHub Container Registry"
+        hostname: ghcr.io
+        login_required: false
+      - name: "Kubernetes Container Registry"
+        hostname: registry.k8s.io
+        login_required: false
 
 # install validating webhook by default
 validatingWebhook:


### PR DESCRIPTION
Add the GitHub ghcr.io and the Kubernetes registry.k8s.io container registries to the defaults in the helm chart.