### PR TITLE
Cluster wizard now scrolls

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-info/cluster-info.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-info/cluster-info.component.ts
@@ -175,7 +175,8 @@ export class ClusterInfoComponent implements OnInit {
   openClusterWizard() {
     const openAddCluster = this.dialog.open(AddClusterWizardComponent, {
       width: '900px',
-      height: 'auto',
+      height: '75%',
+      minHeight: '300px',
       closeOnNavigation: true,
       disableClose: true,
       data: { cluster: this.cluster, clusterId: this.cluster.id, isEdit: true }

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
@@ -285,7 +285,8 @@ export class ClusterListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.groupId = +this.router.url.split('/').reverse()[0];
     const openAddCluster = this.dialog.open(AddClusterWizardComponent, {
       width: '900px',
-      height: this.isChartInSmallDevice ? '300px' : 'auto',
+      height: '75%',
+      minHeight: '300px',
       closeOnNavigation: true,
       disableClose: true,
       data: { groupId: this.groupId }

--- a/dash/frontend/src/app/modules/private/pages/dashboard/dashboard.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ClusterService } from '../../../../core/services/cluster.service';
@@ -128,7 +128,8 @@ export class DashboardComponent implements OnInit {
   openDefaultCreateClusterDialog() {
     const openAddCluster = this.dialog.open(AddClusterWizardComponent, {
       width: '900px',
-      height: 'auto',
+      height: '75%',
+      minHeight: '300px',
       closeOnNavigation: true,
       disableClose: true,
       data: { groupId:  null}


### PR DESCRIPTION
Root cause: Having 'height: auto' on the dialog with responsive content caused a deadlock.
Quick summary: the 'height auto' made the dialog want to grow to the size of the content, but the content wanted o grow based on the size of the dialog. This causes the container to grow to a size where it doesn't need to scroll (but isn't fully visible on the screen).

Solution: set the dialog height to 75% (with a min height for small devices), Causing it to be a more reasonable size, and will now scroll if needed.