### PR TITLE
Fix for Gatekeeper sync issue 

### DIFF
--- a/dash/backend/.env.sample
+++ b/dash/backend/.env.sample
@@ -109,4 +109,4 @@ IS_LOCAL=True
 #######################################################
 #./config/gatekeeper.ts
 #######################################################
-GATEKEEPER_TEMPLATE_DIR=gatekeeper-templates
+GATEKEEPER_TEMPLATE_DIR=dist/gatekeeper-templates

--- a/dash/backend/src/modules/command-line/services/exception-block.service.ts
+++ b/dash/backend/src/modules/command-line/services/exception-block.service.ts
@@ -252,19 +252,16 @@ export class ExceptionBlockService {
         for (const namespace of exception.namespaces) {
             namespaceRego += ` pod.metadata.namespace == "${namespace.name}",\n `;
         }
-        if (imagePattern === '') {
-
-        } else {
+        if (imagePattern !== '') {
             for (const namespace of exception.namespaces) {
                 namespaceRegoWithImagePattern += ` {pod.metadata.namespace == "${namespace.name}",\n   regex.match("${imagePattern}", container.image)},\n `;
             }
         }
         const template = `# Exception ${exception.id} - ${exception.title} #\n ${namespaceRego === '' ? ` true\n` : namespaceRego}\n  `;
         exceptionBlock += template;
-        const templateWithImagePattern = `# Exception ${exception.id} - ${exception.title} #\n ${namespaceRegoWithImagePattern === '' ? ` {true, true}\n` : namespaceRegoWithImagePattern}\n  `;
+        const templateWithImagePattern = `# Exception ${exception.id} - ${exception.title} #\n ${namespaceRegoWithImagePattern === '' ? ` {true, true},\n` : namespaceRegoWithImagePattern}\n  `;
         exceptionBlockWithImagePattern += templateWithImagePattern;
 
         return { exceptionBlock, exceptionBlockWithImagePattern }
     }
-
 }

--- a/dash/backend/src/modules/exceptions/dao/exceptions.dao.ts
+++ b/dash/backend/src/modules/exceptions/dao/exceptions.dao.ts
@@ -123,7 +123,7 @@ export class ExceptionsDao {
     ): Promise<ExceptionQueryDto[]> {
         const knex = await this.databaseService.getConnection();
         const today = new Date().toISOString().slice(0, 10); // @TODO: Eventually make this a utility function, perhaps with timezone/locality considered
-        let sql = knex.distinct('ex.id as _id',
+        const sql = knex.distinct('ex.id as _id',
             'ex.issue_identifier as _issueIdentifier',
             'ex.title AS _title',
             'ex.type as _type',
@@ -155,7 +155,7 @@ export class ExceptionsDao {
                     .orWhere('ex.end_date', '>', today);
             })
             .andWhere(function() {
-                let cond = this.where({
+                const cond = this.where({
                     'ex.relevant_for_all_clusters': true
                 });
 
@@ -166,7 +166,7 @@ export class ExceptionsDao {
                 }
             })
             .andWhere(function() {
-                let cond = this.where({
+                const cond = this.where({
                     'ex.relevant_for_all_policies': true
                 });
 
@@ -175,7 +175,7 @@ export class ExceptionsDao {
                 }
             })
             .andWhere(function() {
-                let cond = this.where({
+                const cond = this.where({
                     'ex.relevant_for_all_kubernetes_namespaces': true
                 });
 
@@ -235,7 +235,6 @@ export class ExceptionsDao {
             .leftJoin('clusters AS cl', 'cl.id', 'cluster_ex.cluster_id')
             .where('ex.status', 'active')
             .andWhere('ex.type', 'gatekeeper')
-            .andWhere('ex.issue_identifier', '')
             // .andWhere('ex.relevant_for_all_clusters', true)
             .andWhere('ex.deleted_at', null);
         return await knexnest(sql).then(data => data);


### PR DESCRIPTION
# Main issue
the calculateExceptionBlock function in the exceptionBlockService builds the body of a rego array.
When their are no image-specific exceptions, it defaults to adding '{true, true}'. Unlike the similar logic for non-image specific exceptions, there is no comma after this {true, true}.

If an exception hits this case, and has at least one more exception processed after it, this will cause a rego syntax error.

Works by coincidence if this kind of exception was the only exception or the exception applied last, as then that comma would be optional. (having it for the last doesn't matter as trailing commas are legal in rego)

## Side issue
When getting the gatekeeper exceptions, exceptions were being filtered to only include ones whose issue_identifier was an empty string. However, new gatekeeper exceptions would have that as null rather than an empty string, and if someone used edit mode to repurpose an existing exception it could actually have something in it.

I simply removed this condition, as that field is effectively unused for this kind of exception.

# Misc other changes
- .env.sample GATEKEEPER_TEMPLATE_DIR was not set to the correct path, made match default from gatekepper.ts in config directory
- Fixed some linter complaints
  - if...else with no body to if converted to if
  - several let's changed to const's for variables that were never modified.