### PR TITLE
A couple small bug fixes

### DIFF
--- a/dash/backend/src/modules/policy/controllers/policy.controller.ts
+++ b/dash/backend/src/modules/policy/controllers/policy.controller.ts
@@ -76,8 +76,8 @@ export class PolicyController {
                 HttpStatus.UNPROCESSABLE_ENTITY)
         }
         const createdPolicy: PolicyDto = await this.policyService.createPolicy(policyData.policy);
-        createdPolicy.metadata = await this.policyService.calculatePolicyMetadata(null, createdPolicy);
         if (createdPolicy) {
+            createdPolicy.metadata = await this.policyService.calculatePolicyMetadata(null, createdPolicy);
             if (policyData.scanners && policyData.scanners.length > 0) {
                 await Promise.all(policyData.scanners.map(scanner => {
                     scanner.policyId = createdPolicy.id;
@@ -94,7 +94,7 @@ export class PolicyController {
             }
             return createdPolicy;
         } else {
-            throw new HttpException({ status: HttpStatus.INTERNAL_SERVER_ERROR, message: 'Policy Name already exists', entityType: 'Policy'}, HttpStatus.INTERNAL_SERVER_ERROR)
+            throw new HttpException({ status: HttpStatus.CONFLICT, message: 'Policy Name already exists', entityType: 'Policy'}, HttpStatus.CONFLICT)
         }
     }
 


### PR DESCRIPTION
# Bug 1 - Gatekeeper & policy exceptions couldn't be created
The validation had the altSeverity field on the exception create/edit field marked as required. This made users unable to submit gatekeeper & policy exceptions since that field is only visible on the override exception form.

Solution: subscribed to value changes for the type field, and change the validators on the altSeverity field accordingly.

# Bug 2 - 500 Internal Server error when trying to submit policy with a duplicate name
The error was caused because they attempted to add the metadata object to the policy without checking if it had been created or not.

Solution: moved that line to within the if statement checking for its existence.
Also changed the status code for the policy name already existing from 500 to 409 (Conflict)
