### PR TITLE
Angular Upgrade follow up

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-edit/cluster-edit.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-edit/cluster-edit.component.html
@@ -8,7 +8,7 @@
         </mat-form-field>
       </p>
       <!-- <p>
-        <mat-form-field appearance="standard">
+        <mat-form-field>
           <mat-label>Grace Period Days</mat-label>
           <input matInput placeholder="0" type="text" formControlName="gracePeriodDays">
         </mat-form-field>

--- a/dash/frontend/src/app/modules/private/pages/docker-registries/docker-registries-create/docker-registries-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/docker-registries/docker-registries-create/docker-registries-create.component.html
@@ -94,7 +94,7 @@
         </div>
         <div *ngIf="showAzureAuthFields">
           <p>
-            <mat-form-field appearance="standard">
+            <mat-form-field>
               <mat-label>Azure Client ID</mat-label>
               <input matInput placeholder="Client ID" type="text" formControlName="azureClientId">
               <mat-hint *ngIf="createDockerRegistryForm.get('azureClientId').errors &&
@@ -103,7 +103,7 @@
             </mat-form-field>
           </p>
           <p>
-            <mat-form-field appearance="standard">
+            <mat-form-field>
               <mat-label>Azure Client Secret</mat-label>
               <input matInput [type]="passwordHide ? 'password' : 'text'" formControlName="azureClientSecret">
               <mat-icon matSuffix (click)="passwordHide = !passwordHide">{{passwordHide ? 'visibility_off' : 'visibility'}}</mat-icon>
@@ -113,7 +113,7 @@
             </mat-form-field>
           </p>
           <p>
-            <mat-form-field appearance="standard">
+            <mat-form-field>
               <mat-label>Azure Tenant ID</mat-label>
               <input matInput placeholder="Tenant ID" type="text" formControlName="azureTenantId">
               <mat-hint *ngIf="createDockerRegistryForm.get('azureTenantId').errors &&

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-create/exception-create.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-create/exception-create.component.ts
@@ -51,7 +51,7 @@ export class ExceptionCreateComponent implements OnInit, AfterViewInit, OnDestro
   origSelectedClusters: string[];
   origSelectedNamespaces: string[];
 
-  gatekeeperConstraintList: Observable<IGateKeeperConstraintDetails[]>;
+  gatekeeperConstraintList: Observable<IGateKeeperConstraintDetails[]> = of([]);
   filteredGatekeeperConstraints: Observable<IGateKeeperConstraintDetails[]>;
 
   @ViewChild('issueIdentifierLabel') issueIdentifierLabel;

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.html
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.html
@@ -31,11 +31,11 @@
         <div class="right-column">
           <div *ngIf="!exception?.relevantForAllClusters; else noClusters">
             <h3><b>Clusters</b></h3>
-            <mat-chip-grid>
+            <mat-chip-listbox>
               <mat-chip-option *ngFor="let cluster of exception?.clusters" (click)="viewCluster(cluster?.id)">
                 {{cluster.name}}
               </mat-chip-option>
-            </mat-chip-grid>
+            </mat-chip-listbox>
           </div>
           <ng-template #noClusters>
             <p><b>Clusters:</b> All</p>
@@ -43,11 +43,11 @@
 
           <div *ngIf="!exception?.relevantForAllPolicies; else noPolicies">
             <h3><b>Policies</b></h3>
-            <mat-chip-grid>
+            <mat-chip-listbox>
               <mat-chip-option *ngFor="let policy of exception.policies" (click)="viewPolicy(policy?.id)">
                 {{policy.name}}
               </mat-chip-option>
-            </mat-chip-grid>
+            </mat-chip-listbox>
           </div>
           <ng-template #noPolicies>
             <p><b>Policies:</b> All</p>
@@ -55,11 +55,11 @@
 
           <div *ngIf="!exception?.relevantForAllKubernetesNamespaces; else noNamespaces">
             <h3><b>Namespaces</b></h3>
-            <mat-chip-grid>
+            <mat-chip-listbox>
               <mat-chip-option *ngFor="let namespace of exception.namespaces">
                 {{namespace.name}}
               </mat-chip-option>
-            </mat-chip-grid>
+            </mat-chip-listbox>
           </div>
           <ng-template #noNamespaces>
             <p><b>Namespaces:</b> All</p>

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-rule-add-edit-dialog/falco-rule-add-edit-dialog.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-rule-add-edit-dialog/falco-rule-add-edit-dialog.component.html
@@ -10,7 +10,7 @@
       </mat-form-field>
     </div>
     <div class="row">
-      <mat-form-field appearance="standard">
+      <mat-form-field>
         <mat-label>Clusters</mat-label>
         <mat-select formControlName="clusters" multiple
         (selectionChange)="setVisibleNamespaces()">

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-rules-cluster-list/falco-rules-cluster-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-rules-cluster-list/falco-rules-cluster-list.component.html
@@ -1,15 +1,15 @@
 <mat-card class="card">
-  <mat-card-header>
-    <mat-card-title class="falco-title">
-      <h1>Rules</h1>
-      <button mat-raised-button color="primary"
-      [routerLink]="['/private','falco']">
-        Manage Falco Rules
-      </button>
+  <mat-card-header class="title-with-button">
+    <mat-card-title class="title-with-button">
+        <div class="page-card-title">Rules</div>
+        <button mat-raised-button color="primary"
+        [routerLink]="['/private','falco']">
+          Manage Falco Rules
+        </button>
     </mat-card-title>
   </mat-card-header>
   <mat-card-content class="falco-rule-card-content">
-    <div class="row w-100">
+    <div class="row">
       <div class="col w-100" *ngFor="let rule of rules; index as idx">
       <div class="rule-container">
         <strong>{{rule.action | titlecase}}</strong> when the following are true:

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-rules-cluster-list/falco-rules-cluster-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-rules-cluster-list/falco-rules-cluster-list.component.scss
@@ -13,16 +13,15 @@
   overflow-y: auto;
 }
 
-.w-100 {
-  width: 100%;
-}
+mat-card-header.title-with-button {
+  ::ng-deep.mat-mdc-card-header-text {
+    width: 100%;
+  }
 
-::ng-deep.mat-card-header-text {
-  width: 100%;
-}
-
-.falco-title {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
+  mat-card-title {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
 }

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.html
@@ -6,98 +6,100 @@
       </div>
     </div>
     <div class="page-card">
-      <div> <!--class="col-xl-6"-->
-        <mat-card appearance="outlined" style="height:500px; min-width: 400px; display: grid;!important;">
-          <mat-card-header>
-            <div class="page-card-title"> Notification Settings </div>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="page-card-header" >
-              <div>
-                <form [formGroup]="settingForm">
-                    <div class="section-sublevel-1">
-                      <div class="row page-card-left-align">
-                        <div >
-                          <mat-checkbox (change)="enableAnomalySubLevelcheckbox($event)" formControlName="sendNotificationAnomaly"> </mat-checkbox>
-                        </div>&nbsp;&nbsp;
-                        <div>
-                          Notify about Anomalies
+      <div class="row" style="width: 100%">
+        <div class="col-xs-12 col-lg-6 card-col">
+          <mat-card appearance="outlined" style="height:500px; min-width: 400px; display: grid;!important;">
+            <mat-card-header>
+              <div class="page-card-title"> Notification Settings </div>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="page-card-header" >
+                <div>
+                  <form [formGroup]="settingForm">
+                      <div class="section-sublevel-1">
+                        <div class="row page-card-left-align">
+                          <div >
+                            <mat-checkbox (change)="enableAnomalySubLevelcheckbox($event)" formControlName="sendNotificationAnomaly"> </mat-checkbox>
+                          </div>&nbsp;&nbsp;
+                          <div>
+                            Notify about Anomalies
+                          </div>
+                        </div>
+
+                        <div class="section-sublevel-2">
+                          <div class ="row page-card-left-align">
+                            Notify no more than once every
+                            <mat-form-field  style="width:3em">
+                              <input class="no-spin-button" matInput [readonly]="isNotifyAnomalyDisabled" type="number" formControlName="anomalyFrequency">
+                            </mat-form-field>
+                            day(s)
+                          </div>
+                          <div>
+                            Severity Levels to Include
+
+                            <mat-form-field appearance="fill" [formGroup]="settingForm">
+                              <mat-select [disabled]="isNotifyAnomalyDisabled" formControlName="selectedPriorityLevels" multiple>
+                                <mat-option *ngFor="let level of priorityLevels" [value]="level">
+                                  {{level}}
+                                </mat-option>
+                              </mat-select>
+                            </mat-form-field>
+                          </div>
                         </div>
                       </div>
-
-                      <div class="section-sublevel-2">
-                        <div class ="row page-card-left-align">
-                          Notify no more than once every
-                          &nbsp;&nbsp;
-                            <input [readonly]="isNotifyAnomalyDisabled" type="number" style="width:3em" formControlName="anomalyFrequency">
-                          &nbsp;&nbsp;
-                          day(s)
+                      <!--
+                      <div class="section-sublevel-1">
+                        <div class="row">
+                          <div>
+                            <mat-checkbox (change)="enableSummarySubLevelcheckbox($event)" matInput formControlName="sendNotificationSummary" > </mat-checkbox>
+                          </div>&nbsp;&nbsp;
+                          <div>
+                            <h3>Send Summary Emails</h3>
+                          </div>
                         </div>
-                        <div>
-                          Severity Levels to Include
+                        <div class ="section-sublevel-2">
+                          <mat-radio-group aria-label="SelectSummaryFrequency" formControlName="selectedSummaryFrequency" >
+                            <mat-radio-button [disabled]="isSummaryDisabled" value="daily">Daily</mat-radio-button> <br><br>
+                            <mat-radio-button [disabled]="isSummaryDisabled" (change)="enableWeeklySubLevelcheckbox($event)" value="weekly">Weekly on</mat-radio-button> &nbsp;&nbsp;
 
-                          <mat-form-field appearance="fill" [formGroup]="settingForm">
-                            <mat-select [disabled]="isNotifyAnomalyDisabled" formControlName="selectedPriorityLevels" multiple>
-                              <mat-option *ngFor="let level of priorityLevels" [value]="level">
-                                {{level}}
+                            <mat-select [disabled]="isWeeklyDisabled" class="weekDay" formControlName="selectedWeekDay">
+                              <mat-option *ngFor="let day of weekDays" [value]="day">
+                                {{day}}
                               </mat-option>
                             </mat-select>
-                          </mat-form-field>
-                        </div>
-                      </div>
-                    </div>
-                    <!--
-                    <div class="section-sublevel-1">
-                      <div class="row">
-                        <div>
-                          <mat-checkbox (change)="enableSummarySubLevelcheckbox($event)" matInput formControlName="sendNotificationSummary" > </mat-checkbox>
-                        </div>&nbsp;&nbsp;
-                        <div>
-                          <h3>Send Summary Emails</h3>
-                        </div>
-                      </div>
-                      <div class ="section-sublevel-2">
-                        <mat-radio-group aria-label="SelectSummaryFrequency" formControlName="selectedSummaryFrequency" >
-                          <mat-radio-button [disabled]="isSummaryDisabled" value="daily">Daily</mat-radio-button> <br><br>
-                          <mat-radio-button [disabled]="isSummaryDisabled" (change)="enableWeeklySubLevelcheckbox($event)" value="weekly">Weekly on</mat-radio-button> &nbsp;&nbsp;
-
-                          <mat-select [disabled]="isWeeklyDisabled" class="weekDay" formControlName="selectedWeekDay">
-                            <mat-option *ngFor="let day of weekDays" [value]="day">
-                              {{day}}
-                            </mat-option>
-                          </mat-select>
-                        </mat-radio-group>
-                      </div>
-                    </div>
-                    -->
-                    <br>
-                    <div class="section-sublevel-1">
-                      <div class="row page-card-left-align">
-                        Who to Notify
-                        <div class="section-sublevel-2">
-                          <mat-radio-group aria-label="SelectPerson" formControlName="whoToNotify">
-                            <mat-radio-button (change)="notEnableSpecificEmailSubLevelcheckbox($event)" value="allAdmin">All Admin</mat-radio-button> <br>
-                            <mat-radio-button (change)="enableSpecificEmailSubLevelcheckbox($event)" value="specificEmail">Specific Email List</mat-radio-button>
-                            <br>
-                              <textarea [style.display]="isSpecificEmailHidden? 'none' :'block'" formControlName="emailList"></textarea>
                           </mat-radio-group>
                         </div>
                       </div>
+                      -->
                       <br>
-                      <div class="page-card-left-align">
-                        <button mat-raised-button color="primary" type="submit" (click)="onClickSave()">Save Changes</button>
+                      <div class="section-sublevel-1">
+                        <div class="row page-card-left-align">
+                          Who to Notify
+                          <div class="section-sublevel-2">
+                            <mat-radio-group aria-label="SelectPerson" formControlName="whoToNotify">
+                              <mat-radio-button (change)="notEnableSpecificEmailSubLevelcheckbox($event)" value="allAdmin">All Admin</mat-radio-button> <br>
+                              <mat-radio-button (change)="enableSpecificEmailSubLevelcheckbox($event)" value="specificEmail">Specific Email List</mat-radio-button>
+                              <br>
+                                <textarea [style.display]="isSpecificEmailHidden? 'none' :'block'" formControlName="emailList"></textarea>
+                            </mat-radio-group>
+                          </div>
+                        </div>
+                        <br>
+                        <div class="page-card-left-align">
+                          <button mat-raised-button color="primary" type="submit" (click)="onClickSave()">Save Changes</button>
+                        </div>
                       </div>
-                    </div>
-                </form>
+                  </form>
+                </div>
               </div>
-            </div>
-          </mat-card-content>
-        </mat-card>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        <div class="col-xs-12 col-lg-6 card-col" *ngIf="clusterId">
+          <app-falco-rules-cluster-list
+            [clusterId]="clusterId"
+          ></app-falco-rules-cluster-list>
+        </div>
       </div>
-      <div class="col-sm-6" *ngIf="clusterId">
-        <app-falco-rules-cluster-list
-          [clusterId]="clusterId"
-        ></app-falco-rules-cluster-list>
-    </div>
   </div>
 </div>

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.html
@@ -6,9 +6,9 @@
       </div>
     </div>
     <div class="page-card">
-      <div class="row" style="width: 100%">
+      <div class="row w-100">
         <div class="col-xs-12 col-lg-6 card-col">
-          <mat-card appearance="outlined" style="height:500px; min-width: 400px; display: grid;!important;">
+          <mat-card appearance="outlined" style="min-width: 400px;">
             <mat-card-header>
               <div class="page-card-title"> Notification Settings </div>
             </mat-card-header>
@@ -18,26 +18,19 @@
                   <form [formGroup]="settingForm">
                       <div class="section-sublevel-1">
                         <div class="row page-card-left-align">
-                          <div >
-                            <mat-checkbox (change)="enableAnomalySubLevelcheckbox($event)" formControlName="sendNotificationAnomaly"> </mat-checkbox>
-                          </div>&nbsp;&nbsp;
-                          <div>
-                            Notify about Anomalies
-                          </div>
+                            <mat-checkbox (change)="enableAnomalySubLevelcheckbox($event)" formControlName="sendNotificationAnomaly"> Notify about Anomalies </mat-checkbox>
                         </div>
 
-                        <div class="section-sublevel-2">
-                          <div class ="row page-card-left-align">
-                            Notify no more than once every
-                            <mat-form-field  style="width:3em">
+                        <div class="section-sublevel-2 row">
+                          <div class="col-xs-12">
+                            <mat-form-field>
+                              <mat-label>Days between notification</mat-label>
                               <input class="no-spin-button" matInput [readonly]="isNotifyAnomalyDisabled" type="number" formControlName="anomalyFrequency">
                             </mat-form-field>
-                            day(s)
                           </div>
-                          <div>
-                            Severity Levels to Include
-
+                          <div class="col-xs-12">
                             <mat-form-field appearance="fill" [formGroup]="settingForm">
+                              <mat-label>Severity Levels to Include</mat-label>
                               <mat-select [disabled]="isNotifyAnomalyDisabled" formControlName="selectedPriorityLevels" multiple>
                                 <mat-option *ngFor="let level of priorityLevels" [value]="level">
                                   {{level}}
@@ -71,17 +64,22 @@
                         </div>
                       </div>
                       -->
-                      <br>
+
                       <div class="section-sublevel-1">
-                        <div class="row page-card-left-align">
-                          Who to Notify
-                          <div class="section-sublevel-2">
-                            <mat-radio-group aria-label="SelectPerson" formControlName="whoToNotify">
-                              <mat-radio-button (change)="notEnableSpecificEmailSubLevelcheckbox($event)" value="allAdmin">All Admin</mat-radio-button> <br>
-                              <mat-radio-button (change)="enableSpecificEmailSubLevelcheckbox($event)" value="specificEmail">Specific Email List</mat-radio-button>
-                              <br>
-                                <textarea [style.display]="isSpecificEmailHidden? 'none' :'block'" formControlName="emailList"></textarea>
+                        <div class="col-xs-12">
+                          <mat-label>Who to Notify</mat-label>
+                        </div>
+                        <div class="row page-card-left-align section-sublevel-2">
+                          <div class="col-xs-12 w-100">
+                            <mat-radio-group class="display-flex flex-column" aria-label="SelectPerson" formControlName="whoToNotify">
+                              <mat-radio-button (change)="notEnableSpecificEmailSubLevelcheckbox($event)" value="allAdmin">All Admins</mat-radio-button>
+                              <mat-radio-button (change)="enableSpecificEmailSubLevelcheckbox($event)" value="specificEmail">Specific Email List (comma separated)</mat-radio-button>
                             </mat-radio-group>
+                          </div>
+                          <div class="col-xs-12 w-100">
+                            <mat-form-field [style.display]="isSpecificEmailHidden? 'none' :'block'">
+                              <textarea matInput formControlName="emailList"></textarea>
+                            </mat-form-field>
                           </div>
                         </div>
                         <br>
@@ -102,4 +100,5 @@
         </div>
       </div>
   </div>
+</div>
 </div>

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.scss
@@ -1,8 +1,8 @@
 .section-sublevel-1{
-  margin-left: 25px;
+  margin-left: 24px;
 }
 .section-sublevel-2{
-  margin-left: 50px;
+  margin-left: 46px;
 }
 
 .card-col {

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-settings/falco-settings.component.scss
@@ -4,3 +4,7 @@
 .section-sublevel-2{
   margin-left: 50px;
 }
+
+.card-col {
+  margin-bottom: 32px;
+}

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
@@ -134,7 +134,7 @@
           <span class="subnav-title">Issues</span>
         </div>
         <div class="ml-a">
-          <button mat-button mat-icon-button (click)="downloadCsv()"><mat-icon>download</mat-icon></button>
+          <button mat-icon-button (click)="downloadCsv()"><mat-icon>download</mat-icon></button>
         </div>
       </mat-toolbar>
       <div class="mat-elevation-z8">

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -749,3 +749,18 @@ div.cluster-dashboard.responsive {
   padding-left: 10px;
 }
 
+.w-100 {
+  width: 100%;
+}
+
+/** Hides the increment/decrement arrows on number inputs */
+input[type=number].no-spin-button {
+  -moz-appearance:textfield; /* Firefox */
+
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    // Gets rid of the margin on the (invisible) arrows
+    margin: 0;
+  }
+}

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -730,6 +730,10 @@ div.cluster-dashboard.responsive {
   display: flex;
 }
 
+.flex-column {
+  flex-direction: column;
+}
+
 .action-button-row {
   display: flex;
   justify-content: end;


### PR DESCRIPTION
Fixes for:
- appearance="standard" no longer allowed on form fields, removed where applicable
- exception create component attempted to reference undefined gateKeeperList variable. Now initializes to observeable of empty array
- mat-chip-grid is now only allowed withint form controls. Replace usages outside of forms with mat-chip-lists
- Removed redundant mat-button decorator from a button, as now having duplicate mat-X-button decorators throws errors
- Cleaned up Falco Settings page, as the upgrades caused it to look strange. Did end up changing the aesthetics to be more in line with MAterial design principals, ass the original design would be very difficult to replicate using Angular Material. Image attached of new layout

<img width="1072" alt="Screenshot 2023-07-06 at 12 12 27 PM" src="https://github.com/m9sweeper/m9sweeper/assets/81321170/591189ed-33e3-4544-aa01-3b25afa9708d">
