### PR TITLE
Bug Fixes #2

### DIFF
--- a/dash/backend/src/modules/reports/controllers/reports.controller.ts
+++ b/dash/backend/src/modules/reports/controllers/reports.controller.ts
@@ -73,11 +73,12 @@ export class ReportsController {
         @Query('namespaces') namespaces?: Array<string>,
         @Query('date') date?: string,
         @Query('compliant') isCompliant?: string,
+        @Query('page') page?: string,
     ) {
         if (!limit || limit < 1 || limit > 100) {
             throw new BadRequestException('Please provide a limit between 1 and 100');
         }
-        return this.reportsService.getRunningVulnerabilities(limit, clusterId, namespaces, isCompliant, date);
+        return this.reportsService.getRunningVulnerabilities(limit, clusterId, namespaces, isCompliant, date, page);
     }
 
     @Get('/running-vulnerabilities/download')

--- a/dash/backend/src/modules/reports/dao/reports.dao.ts
+++ b/dash/backend/src/modules/reports/dao/reports.dao.ts
@@ -251,7 +251,7 @@ export class ReportsDao {
     }
 
     async getRunningVulnerabilities(
-      clusterId?: number, options?: {namespaces?: Array<string>, limit?: number, isCompliant?: string}
+      clusterId?: number, options?: {namespaces?: Array<string>, limit?: number, isCompliant?: string, page?: number, }
     ): Promise<ReportsRunningVulnerabilitiesPreviewDto> {
         const {  query, knex } = await this.getRunningVulnerabilitiesQuery(clusterId, options);
 
@@ -263,6 +263,9 @@ export class ReportsDao {
 
         if (options?.limit) {
             query.limit(options.limit);
+        }
+        if (options?.page && options?.limit) {
+            query.offset(options.page * options.limit);
         }
 
         // @ts-ignore
@@ -292,7 +295,7 @@ export class ReportsDao {
       return outerquery.first().then(result => plainToInstance(ReportsRunningVulnerabilitiesSummaryDto, result));
     }
 
-    async getHistoricalRunningVulnerabilities(clusterId: number, date: string, options: {limit?: number, namespaces?: string[], isCompliant?: string})
+    async getHistoricalRunningVulnerabilities(clusterId: number, date: string, options: {limit?: number, namespaces?: string[], isCompliant?: string, page?: number})
         : Promise<ReportsRunningVulnerabilitiesPreviewDto> {
         const knex = await this.databaseService.getConnection();
 
@@ -354,6 +357,9 @@ export class ReportsDao {
 
         if (options?.limit) {
             query.limit(options.limit);
+        }
+        if (options?.page && options?.limit) {
+            query.offset(options.page * options.limit);
         }
 
         const queryResults = await query.then((response) => {

--- a/dash/backend/src/modules/reports/services/reports.service.ts
+++ b/dash/backend/src/modules/reports/services/reports.service.ts
@@ -70,10 +70,10 @@ export class ReportsService {
     }
 
     async getRunningVulnerabilities(limit: number, clusterId?: number, namespaces?: Array<string>,
-      isCompliant?: string, date?: string)
+      isCompliant?: string, date?: string, page?: string)
       : Promise<ReportsRunningVulnerabilitiesPreviewDto>
     {
-        return this.getRunningVulnerabilitiesNoRequirements(clusterId, limit, namespaces, isCompliant, date);
+        return this.getRunningVulnerabilitiesNoRequirements(clusterId, limit, namespaces, isCompliant, date, page);
     }
 
     async getRunningVulnerabilitiesNoRequirements(
@@ -81,14 +81,19 @@ export class ReportsService {
       limit?: number,
       namespaces?: Array<string>,
       isCompliant?: string,
-      date?: string
+      date?: string,
+      page?: string,
     ): Promise<ReportsRunningVulnerabilitiesPreviewDto> {
+        let pageAsNum = 0;
+        if (page) {
+            pageAsNum = parseInt(page);
+        }
         if (date && date !== format(new Date(), 'yyyy-MM-dd')) {
             return this.reportsDao.getHistoricalRunningVulnerabilities(
-              clusterId, date, {limit, namespaces, isCompliant}
+              clusterId, date, {limit, namespaces, isCompliant, page: pageAsNum }
             );
         } else {
-            return this.reportsDao.getRunningVulnerabilities(clusterId, {namespaces, limit, isCompliant});
+            return this.reportsDao.getRunningVulnerabilities(clusterId, {namespaces, limit, isCompliant, page: pageAsNum });
         }
     }
 

--- a/dash/frontend/src/app/app.component.scss
+++ b/dash/frontend/src/app/app.component.scss
@@ -43,9 +43,6 @@ div.kubernetes-object-container {
     * > mat-cell:first-of-type {
       padding-left: 0;
     }
-    * > .mat-mdc-table .mat-mdc-paginator {
-      width: 250px;
-    }
   }
 
   > div {

--- a/dash/frontend/src/app/core/services/reports.service.ts
+++ b/dash/frontend/src/app/core/services/reports.service.ts
@@ -53,7 +53,8 @@ export class ReportsService {
                                    date?: string
                                    startDate?: string
                                    endDate?: string
-                                   compliant?: boolean
+                                   compliant?: boolean,
+                                   page?: number,
                                  }
                                  ): HttpParams {
     let exportParams = new HttpParams()
@@ -86,12 +87,15 @@ export class ReportsService {
     if (options?.compliant?.toString()) {
       exportParams = exportParams.set('compliant', options.compliant.toString());
     }
+    if (options?.page?.toString()) {
+      exportParams = exportParams.set('page', options.page.toString());
+    }
     return exportParams;
   }
 
-  getRunningVulnerabilities(limit: number, clusterId: number, namespaces?: Array<string>, date?: string, compliant?: boolean):
+  getRunningVulnerabilities(limit: number, clusterId: number, namespaces?: Array<string>, date?: string, compliant?: boolean, page?: number):
     Observable<IServerResponse<IRunningVulnerabilitiesPreview>> {
-    const params = this.buildReportQueryParams(clusterId, {namespaces, limit, date, compliant});
+    const params = this.buildReportQueryParams(clusterId, {namespaces, limit, date, compliant, page});
     return this.httpClient.get(`${this.baseUrl}/running-vulnerabilities`, {params});
   }
 

--- a/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.html
@@ -39,12 +39,12 @@
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
         </table>
-          <mat-paginator
-            [length]="totalCount"
-            [pageSize]="limit"
-            [pageSizeOptions]="[10, 20, 50, 100]"
-            (page)="pageEvent($event)"
-            showFirstLastButtons></mat-paginator>
+        <mat-paginator
+          [length]="totalCount"
+          [pageSize]="limit"
+          [pageSizeOptions]="[10, 20, 50, 100]"
+          (page)="pageEvent($event)"
+          showFirstLastButtons></mat-paginator>
       </div>
     </div>
 </div>

--- a/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.scss
@@ -1,0 +1,4 @@
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}

--- a/dash/frontend/src/app/modules/private/pages/docker-registries/docker-registries-list/docker-registries-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/docker-registries/docker-registries-list/docker-registries-list.component.scss
@@ -1,1 +1,4 @@
-
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-list/exception-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-list/exception-list.component.scss
@@ -1,0 +1,4 @@
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-list/external-auth-configuration-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-list/external-auth-configuration-list.component.scss
@@ -1,1 +1,5 @@
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}
 

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.html
@@ -123,7 +123,7 @@
         </mat-card-header>
         <mat-card-content>
 
-          <div class="falco-table">
+          <div class="falco-table page-table">
             <mat-table [dataSource]="dataSource">
 
               <ng-container matColumnDef="calendarDate">

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.scss
@@ -6,76 +6,59 @@
 }
 
 .falco-table {
-  overflow-y: auto !important;
-  mat-table {
-    mat-row {
-      min-height: 24px !important
-    }
+  .mat-column-calendarDate {
+    width: 100px;
+    min-width: 50px;
+    max-width: 100px;
+    padding-right: 5px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-    mat-header {
-      min-height: 32px !important
-    }
+  .mat-column-namespace {
+    width: 120px;
+    min-width: 100px;
+    max-width: 120px;;
+    padding-right: 10px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-    mat-cell, mat-header-cell, mat-footer-cell {
-      overflow: visible;
-    }
+  .mat-column-pod {
+    width: 120px;
+    min-width: 100px;
+    max-width:120px;;
+    //max-width: 7%;
+    padding-right: 10px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-    .mat-column-calendarDate {
-      width: 100px;
-      min-width: 50px;
-      max-width: 100px;
-      margin-right: 5px;
-      overflow: hidden;
-      white-space: nowrap;
-    }
+  .mat-column-image {
+    //max-width: 7%;
+    width: 150px;
+    min-width: 100px;
+    max-width: 150px;;
+   //white-space: nowrap;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-    .mat-column-namespace {
-      width: 120px;
-      min-width: 100px;
-      max-width: 120px;;
-      margin-right: 10px;
-      overflow: hidden;
-      white-space: nowrap;
-    }
+  .mat-column-priority {
+    width: 100px;
+    min-width: 50px;
+    max-width:100px;
+    padding-right: 10px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-    .mat-column-pod {
-      width: 120px;
-      min-width: 100px;
-      max-width:120px;;
-      //max-width: 7%;
-      margin-right: 10px;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .mat-column-image {
-      //max-width: 7%;
-      width: 150px;
-      min-width: 100px;
-      max-width: 150px;;
-      margin-right: 10px;
-     //white-space: nowrap;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .mat-column-priority {
-      width: 100px;
-      min-width: 50px;
-      max-width:100px;
-      margin-right: 10px;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .mat-column-message {
-      //max-width: 60%;
-      //width: 200px;
-      min-width: 200px;
-      text-align: center;
-      white-space: nowrap;
-      overflow: hidden;
-      white-space: nowrap;
-    }
+  .mat-column-message {
+    //max-width: 60%;
+    //width: 200px;
+    min-width: 200px;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
   }
 }

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.ts
@@ -21,8 +21,6 @@ import {JwtAuthService} from '../../../../../core/services/jwt-auth.service';
 import {AlertService} from '@full-fledged/alerts';
 
 
-
-
 @Component({
   selector: 'app-falco-events-list',
   templateUrl: './falco-events-list.component.html',

--- a/dash/frontend/src/app/modules/private/pages/policies/policy-list/policy-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/policies/policy-list/policy-list.component.scss
@@ -1,0 +1,4 @@
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}

--- a/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.html
@@ -4,24 +4,27 @@
       <span>Reports</span>
     </div>
     <div class="row">
-      <div *ngFor="let reportInfo of listOfReports" class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
-        <mat-card
-          appearance="outlined"
-          class="cluster-card"
+      <div *ngFor="let reportInfo of listOfReports" class="col-xs-12 col-sm-12 col-md-6 col-lg-4 card-div">
+        <a
           [routerLink]="reportInfo.path"
+          class="report-card"
         >
-          <mat-card-content>
-            <div class="row">
-              <div class="col-xs-3 report-icon">
-                <mat-icon>{{reportInfo.icon}}</mat-icon>
+          <mat-card
+            appearance="outlined"
+          >
+            <mat-card-content>
+              <div class="row" style="display: flex; flex-direction: row">
+                <div class="report-icon">
+                  <mat-icon>{{reportInfo.icon}}</mat-icon>
+                </div>
+                <div class="report-info">
+                  <p class="title-font report-title">{{reportInfo.title}}</p>
+                  <p class="report-description">{{reportInfo.description}}</p>
+                </div>
               </div>
-              <div class="col-xs-9 report-info">
-                <p class="title-font report-title">{{reportInfo.title}}</p>
-                <p class="report-description">{{reportInfo.description}}</p>
-              </div>
-            </div>
-          </mat-card-content>
-        </mat-card>
+            </mat-card-content>
+          </mat-card>
+        </a>
       </div>
     </div>
   </div>

--- a/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.html
@@ -12,10 +12,10 @@
         >
           <mat-card-content>
             <div class="row">
-              <div class="col-xs-2 report-icon">
+              <div class="col-xs-3 report-icon">
                 <mat-icon>{{reportInfo.icon}}</mat-icon>
               </div>
-              <div class="col-xs-10">
+              <div class="col-xs-9 report-info">
                 <p class="title-font report-title">{{reportInfo.title}}</p>
                 <p class="report-description">{{reportInfo.description}}</p>
               </div>

--- a/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.scss
@@ -15,8 +15,9 @@
 
 .report-icon {
   display: flex;
-  justify-content: center;
+  justify-content: right;
   align-self: center;
+  padding-right: 0;
   mat-icon {
     height: unset;
     width: unset;

--- a/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/reports/reports-list/reports.component.scss
@@ -9,15 +9,28 @@
 
 .mat-mdc-card:hover {
   background-color: #F2F2F2;
-  color: black;
-  cursor: pointer;
+}
+
+.card-div {
+  margin: 1em 0 1em 0;
+
+  .report-card {
+    color: black;
+    text-decoration: none;
+
+    mat-card {
+      height: 100%;
+    }
+  }
 }
 
 .report-icon {
   display: flex;
-  justify-content: right;
+  justify-content: center;
   align-self: center;
   padding-right: 0;
+  margin: 0 0.5em 0 0.5em;
+  width: 3em;
   mat-icon {
     height: unset;
     width: unset;
@@ -25,9 +38,15 @@
   }
 }
 
-.report-title {
-  margin-block-end: 0.5em;
-}
-.report-description {
-  margin-block-start: 0.5em;
+.report-info {
+  flex: 1;
+  margin: 0 0.5em 0 0.25em;
+
+  .report-title {
+    margin-block-end: 0.5em;
+  }
+
+  .report-description {
+    margin-block-start: 0.5em;
+  }
 }

--- a/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.html
@@ -71,7 +71,7 @@
         <mat-card-header>
           <div class="row full-width">
             <div class="col-xs-9 vulnerability-count">
-              <p class="title-font title-margin">Displaying {{limit}} out of {{vulnerabilityCount}} vulnerabilities</p>
+              <p class="title-font title-margin">Displaying {{lowNumCurrentShownVulnerabilities}}-{{highNumCurrentShownVulnerabilities}} out of {{vulnerabilityCount}} vulnerabilities</p>
             </div>
             <div class="col-xs-3 vulnerability-download-button">
               <button (click)="downloadReport()"
@@ -142,10 +142,15 @@
                 <mat-cell *matCellDef="let vulnerability">{{vulnerability.totalFixableNegligible}}</mat-cell>
               </ng-container>
 
-
               <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
               <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
             </mat-table>
+            <mat-paginator
+              [length]="vulnerabilityCount"
+              [pageSize]="20"
+              [pageSizeOptions]="[ 10, 20, 50 ]"
+              (page)="pageEvent($event)"
+            ></mat-paginator>
           </div>
         </mat-card-content>
       </mat-card>

--- a/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.scss
@@ -1,3 +1,12 @@
 .mat-mdc-card {
   max-width: 2000px;
 }
+.vulnerability-filter-card mat-row {
+  height: unset;
+}
+//.mat-column-image {
+//  margin-right: unset;
+//}
+//.mat-column-namespaces {
+//  margin-right: unset;
+//}

--- a/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.scss
@@ -4,9 +4,3 @@
 .vulnerability-filter-card mat-row {
   height: unset;
 }
-//.mat-column-image {
-//  margin-right: unset;
-//}
-//.mat-column-namespaces {
-//  margin-right: unset;
-//}

--- a/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
 import {ReportsService} from '../../../../../core/services/reports.service';
 import {ActivatedRoute} from '@angular/router';
 import {take} from 'rxjs/operators';
@@ -10,6 +10,7 @@ import {CsvService} from '../../../../../core/services/csv.service';
 import {AlertService} from '@full-fledged/alerts';
 import {IRunningVulnerabilities} from '../../../../../core/entities/IRunningVulnerabilitiesPreview';
 import {format} from 'date-fns';
+import {MatPaginator} from '@angular/material/paginator';
 
 
 @Component({
@@ -17,10 +18,14 @@ import {format} from 'date-fns';
   templateUrl: './running-vulnerabilities.component.html',
   styleUrls: ['./running-vulnerabilities.component.scss']
 })
-export class RunningVulnerabilitiesComponent implements OnInit {
+export class RunningVulnerabilitiesComponent implements OnInit, AfterViewInit {
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
   clusterId: number;
   vulnerabilityCount: number;
   limit: number;
+  page = 0;  // which page we're on
+  lowNumCurrentShownVulnerabilities: number;
+  highNumCurrentShownVulnerabilities: number;
   vulnerabilities: Array<IRunningVulnerabilities>;
   dataSource: MatTableDataSource<IRunningVulnerabilities>;
   displayedColumns: string[] = ['image', 'namespaces', 'scanResults', 'lastScanned', 'totalCritical', 'totalMajor',
@@ -42,6 +47,12 @@ export class RunningVulnerabilitiesComponent implements OnInit {
 
   ngOnInit() {
     this.limit = 20;
+    this.filterForm = this.formBuilder.group({
+      limit: [this.limit, [Validators.required, Validators.min(1)]],
+      namespaces: [[]],
+      date: [],
+      isCompliant: []
+    });
     this.route.parent.parent.params
       .pipe(take(1))
       .subscribe(param => this.clusterId = param.id);
@@ -56,24 +67,40 @@ export class RunningVulnerabilitiesComponent implements OnInit {
         }
         this.clusterNamespaces.sort();
       });
-
-    this.filterForm = this.formBuilder.group({
-      limit: [this.limit, [Validators.required, Validators.min(1)]],
-      namespaces: [[]],
-      date: [],
-      isCompliant: []
-    });
+  }
+  ngAfterViewInit() {
+    this.paginator.pageSize = this.limit;
   }
 
-  buildReport(limit: number, clusterId: number, namespaces?: string[], date?: string, isCompliant?: boolean) {
+  pageEvent(pageEvent: any) {
+    this.page = pageEvent.pageIndex;
+
+    this.buildReport(
+      pageEvent.pageSize,
+      this.clusterId,
+      this.filterForm.get('namespaces').value,
+      this.filterForm.get('isCompliant').value
+    ); // reload when page event changes
+  }
+
+  buildReport(limit: number, clusterId: number, namespaces?: string[], isCompliant?: boolean) {
     this.loaderService.start();
-    this.reportsService.getRunningVulnerabilities(limit, clusterId, namespaces, date, isCompliant)
+    let date;
+    if (this.filterForm.get('date').value) {
+      date = format(new Date(this.filterForm.get('date').value), 'yyyy-MM-dd');
+    }
+    this.reportsService.getRunningVulnerabilities(limit, clusterId, namespaces, date, isCompliant, this.page)
       .pipe(take(1))
       .subscribe(response => {
         this.vulnerabilityCount = response.data.count;
         this.vulnerabilities = response.data.results;
         this.dataSource = new MatTableDataSource(response.data.results);
         this.limit = limit;
+        this.paginator.pageSize = limit;
+        this.filterForm.get('limit').setValue(limit);
+        console.log({limit: this.limit, page: this.page, response});
+        this.lowNumCurrentShownVulnerabilities = (this.limit * this.page) + 1;
+        this.highNumCurrentShownVulnerabilities = (this.limit * this.page) + response.data.results.length;
         if (this.vulnerabilityCount < this.limit) {
           this.limit = this.vulnerabilityCount;
         }
@@ -95,27 +122,25 @@ export class RunningVulnerabilitiesComponent implements OnInit {
       this.alertService.warning('Invalid filter settings; please recheck filter values');
     }
     else {
-      const newLimit = this.filterForm.get('limit').value;
+      this.paginator.pageIndex = 0;
+      this.page = 0;
       this.previousRequest = {
         namespaces: this.filterForm.get('namespaces').value,
         isCompliant: this.filterForm.get('isCompliant').value
       };
-      let date;
-      if (this.filterForm.get('date').value) {
-        date = format(new Date(this.filterForm.get('date').value), 'yyyy-MM-dd');
-      }
+      const newLimit = this.filterForm.get('limit').value;
       this.buildReport(
         newLimit,
         this.clusterId,
         this.filterForm.get('namespaces').value,
-        date,
         this.filterForm.get('isCompliant').value
       );
     }
   }
 
   get filtersValid(): boolean {
-    return this.filterForm.valid;
+    return true;
+    // return this.filterForm.valid;
   }
 
   downloadReport() {

--- a/dash/frontend/src/app/modules/private/pages/user/user-list/user-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/user/user-list/user-list.component.scss
@@ -1,0 +1,4 @@
+.page-container-content table {
+  overflow-x: scroll;
+  display: block;
+}

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -393,11 +393,16 @@ mat-form-field {
   mat-table {
     min-width: 800px;
 
+    mat-row {
+      height: unset;
+    }
+
     mat-cell, mat-header-cell, mat-footer-cell {
       overflow: visible;
       word-break: break-word;
       overflow-wrap: break-word;
-      padding-right: 5px;
+      padding-left: 10px;
+      padding-right: 10px;
     }
 
     & .mat-column-date {
@@ -556,7 +561,7 @@ mat-form-field {
 
 .mat-column-image {
   word-break: break-all;
-  margin-right: 10px
+  padding-right: 10px
 }
 
 .mat-column-type {

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -403,6 +403,7 @@ mat-form-field {
       overflow-wrap: break-word;
       padding-left: 10px;
       padding-right: 10px;
+      margin-right: unset;
     }
 
     & .mat-column-date {

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -243,10 +243,6 @@ app-private {
   margin: 20px;
   // width:fit-content;
 }
-.page-card{
-  margin: 0px;
-  overflow-x: auto;
-}
 .page-card-header{
   display:flex;
   padding:0px;

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -318,12 +318,6 @@ app-private {
   margin-right: 0px;
 }
 
-.cluster-card {
-  height: 100%;
-  margin-top: 5px;
-  margin-bottom: 30px;
-}
-
 .table-row {
   &:hover {
     background-color: rgba(0, 0, 0, .05);

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -404,6 +404,7 @@ mat-form-field {
       padding-left: 10px;
       padding-right: 10px;
       margin-right: unset;
+      min-width: 8em;
     }
 
     & .mat-column-date {


### PR DESCRIPTION
- Falco page: use global table styling
- Running Vulnerabilities report:
   - use global table styling
   - add pagniation (adds it as an option for the backend as well - defaults to 0 and only uses it if limits is also set)
- set min-width for table columns so they're legible on small screen
- adjust formatting on the list of available reports
- Org Settings pages: make table content scrollable