### PR TITLE
Update Validating Webhook proxy documentation

### DIFF
--- a/dash/backend/scripts/proxy-webhook/README.md
+++ b/dash/backend/scripts/proxy-webhook/README.md
@@ -1,31 +1,33 @@
-# Setup Validating Webhook for AKS
+# Setup Validating Webhook Proxy
 
-Azure Kubernetes Services does not allow kubernetes' API to reach out to a remote cluster or remote ingress when validating whether a pod is allowed to boot or not. 
-Therefore, we have to set it up to connect to a pod in the local cluster as well as setup the appropriate CA, Public, and Private Keys to enable SSL. Then the 
-validating webhook can be hit by the Kubernetes API when validating whether a pod is compliant and allowed to boot up. 
+In some installations of Kubernetes such as Azure Kubernetes Services (AKS) and Google Kubernetes Engine (GKE) as well as some others depending upon configuration, the kubernetes' API is not allowed to reach out to a remote cluster or
+a remote ingress when validating whether a pod is allowed to boot or not. Therefore, we have to set it up to connect to a pod in the local cluster as well as setup the appropriate Certificate Authority, Public, and Private Keys to enable SSL.
+This will allow the validating webhook to be hit by the Kubernetes API when validating whether a pod is compliant and allowed to boot up.
 
-The auto-setup.sh script is an easy way to get a reverse proxy running in a nginx pod as well as setting up the validating webhook with reasonable defaults. 
+The auto-setup.sh script is an easy way to get a reverse proxy running in a nginx pod as well as setting up the validating webhook with reasonable defaults.
 
 
 
 ## How to run
 
-Prerequisites: 
+Prerequisites:
 
  - This assumes you have kubectl and bash/zsh setup locally
  - This assumes you have m9sweeper installed (the script defaults to the m9sweeper-system namespace but can be changed with option flags)
+ - This assumes you have cloned or downloaded the m9sweeper repository and you have a terminal open to this folder.
 
 1. Change the permission of the auto-setup.sh file:
-    
+
     `chmod +x auto-setup.sh`
-    
+
     And then run:
-    
+
     `./auto-setup.sh -n NAMESPACE -u M9SWEEPER_URL -c CLUSTERID`
+
 2. Setup will continue, and if there are no errors the proxy will be up and running.
 ## NOTE:
 * You can run the command as ./auto-setup.sh without the options for a default installation.
-* You can run ./auto-setup.sh -h for a breif help line. 
+* You can run ./auto-setup.sh -h for a breif help line.
 * -n should be the same namespace m9sweeper is installed into. The default is m9sweeper-system
 * -u takes the BASE URL that the reverse proxy should direct to (e.g Example: https://m9sweeper.yourdomain.com) the default is for a local cluster install at http://m9sweeper-dash.m9sweeper-system.svc.cluster.local:3000
 * -c this is the clusterID of your cluster. The default is 1

--- a/docs/content/en/docs/Getting started/advanced-install.md
+++ b/docs/content/en/docs/Getting started/advanced-install.md
@@ -19,6 +19,11 @@ if you a new version is available or if your environment is no longer being moni
 
 ### Installation
 
+{{% alert title="Installation Note" color="primary" %}}
+If you are installing this on Azure Kubernetes Services (AKS) or Google Kubernetes Engine (GKE) or any other installation where the kubernetes API is blocked from reaching
+out to external URL for things such as Validating Webhooks, please see the section below reguarding Validating Webhook installations.
+{{% /alert %}}
+
 We recommend putting your configuration in a values.yaml file and then deploying our app using helm. This
 example uses "helm upgrade --install", which is an idempotent way of installing and/or upgrading the app. This
 is repeatable and the same command can be run regardless of whether you intend to upgrade or install the app.
@@ -42,13 +47,12 @@ which chart version you are deploying. By default, it installs the latest versio
 ## Validating Webhook
 
 If you wish to have m9sweeper prevent applications from booting up that are not compliant with your specified
-policies, you will need the validating webhook. This installs automatically and should work without any configuration.
+policies, you will need the validating webhook. This installs automatically and should work without any configuration in most installations.
 
-However, **if you are running in Azure Kubernetes Service** OR have the kubernetes api firewalled in such a way that it
-cannot reach out to a remote url for the validating webhook, then you will need to
-[setup an nginx reverse proxy](https://github.com/m9sweeper/m9sweeper/blob/main/dash/backend/scripts/proxy-webhook/README.md)
-using our reverse proxy self-installer. This script will generate a CA Certificate Bundle and Nginx configuration
-to enable the reverse proxy to work in Azure Kubernetes Service.
+However, in some installations of Kubernetes such as Azure Kubernetes Services (AKS) and Google Kubernetes Engine (GKE) as well as some others depending upon configuration, the kubernetes' API is not allowed to reach out to a remote cluster or
+a remote ingress when validating whether a pod is allowed to boot or not. Therefore, we have to set it up to connect to a pod in the local cluster as well as setup the appropriate Certificate Authority, Public, and Private Keys to enable SSL.
+This will allow the validating webhook to be hit by the Kubernetes API when validating whether a pod is compliant and allowed to boot up. To assist in this process we have developed a script that will install a nginx reverse proxy that will allow
+your kubernetes API to reach the validating webhook. For information on utilizing this script, please see the scripts documentation on our GitHub page [here](https://github.com/m9sweeper/m9sweeper/blob/main/dash/backend/scripts/proxy-webhook/README.md).
 
 ## Falco bulkhead Deployment
 

--- a/docs/content/en/docs/Getting started/easy-install.md
+++ b/docs/content/en/docs/Getting started/easy-install.md
@@ -24,4 +24,9 @@ own username/password and the API Key to something random/unpredictable.
 Many more options are available. For serious enterprise deployments, we recommend creating a helm
 values.yaml file and versioning this in a code repository to make upgrades easier.
 
-For more information, see the [advanced install guide](../advanced-install).
+For more information, please see the [advanced installation guide](../advanced-install).
+
+{{% alert title="Installation Note" color="primary" %}}
+If you are installing this on Azure Kubernetes Services (AKS) or Google Kubernetes Engine (GKE) or any other installation where the kubernetes API is blocked from reaching
+out to external URL for things such as Validating Webhooks, please see the section reguarding Validating Webhook installations in the [advanced installation guide](../advanced-install).
+{{% /alert %}}


### PR DESCRIPTION
Updates the documentation to show that it is for more than just AKS and adds alerts to some sections to refer to the Validating Webhook Proxy section in the docs for more information.