### PR TITLE
Images Pages Re-Formatting

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.scss
@@ -4,6 +4,8 @@
 }
 
 mat-card.overview-graph-card {
+  margin: 10px 5px 0 5px;  // set to match legacy margins
+
   mat-card-content {
     margin: 6px 16px 16px 6px !important;
     padding: unset;

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
@@ -132,6 +132,7 @@ export class ClusterListComponent implements OnInit, OnDestroy, AfterViewInit {
     this.height = window.innerHeight;
     // default column sizes before calculating them
     this.route.params.subscribe(routeParams => {
+      this.setChartHeightWidthWithoutTimeout();  // starts at a reasonable size
       this.groupId = +routeParams.groupId;
       this.clusterGroupService.setCurrentGroupId(this.groupId);
       this.clusterGroupService.getClusterGroupById(+routeParams.groupId)
@@ -176,22 +177,25 @@ export class ClusterListComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   setChartHeightWidth(){
-    // debounce chart resizing
     clearTimeout(this.resizeTimeout);
     this.resizeTimeout = setTimeout(() => {
-      const innerWindow = document.getElementsByTagName('app-cluster-list').item(0) as HTMLElement;
+      this.setChartHeightWidthWithoutTimeout();
+    }, 1000);
+  }
 
-      this.lineChartAttributes.view = this.chartSizeService.getChartSize(
-        innerWindow?.offsetWidth,
-        { xs: 1, s: 1, m: 2, l: 3 },
-        { left: 20, right: 20 },
-        { left: 20, right: 20 },
-        { left: 5, right: 5 },
-        { left: 6, right: 16 },
-      );
-      this.barChartAttributes.view = this.lineChartAttributes.view;
-      this.complianceSummaryLineChartAttributes.view = this.lineChartAttributes.view;
-    } , 100);
+  setChartHeightWidthWithoutTimeout(){
+    const innerWindow = document.getElementsByTagName('app-cluster-list').item(0) as HTMLElement;
+
+    this.lineChartAttributes.view = this.chartSizeService.getChartSize(
+      innerWindow?.offsetWidth,
+      { xs: 1, s: 1, m: 2, l: 3 },
+      { left: 20, right: 20 },
+      { left: 20, right: 20 },
+      { left: 5, right: 5 },
+      { left: 6, right: 16 },
+    );
+    this.barChartAttributes.view = this.lineChartAttributes.view;
+    this.complianceSummaryLineChartAttributes.view = this.lineChartAttributes.view;
   }
 
   getClustersByClusterGroupId(groupId: number) {

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.html
@@ -151,8 +151,8 @@
 
     <div class="row" id="cluster-vulnerability-table-row">
       <div class="namespaces-table no-padding col-xs-12">
-        <mat-card class="scrollable-table-card table-wrapper">
-          <div class="namespace-image-table">
+        <mat-card class="scrollable-table-card">
+          <div class="table-wrapper">
             <mat-table [dataSource]="dataSource" class="w-100" matSort  matSortActive="namespace" matSortDisableClear matSortDirection="asc">
               <ng-container  matColumnDef="namespace">
                 <mat-header-cell class="padding-left-3" *matHeaderCellDef mat-sort-header disableClear>Namespaces</mat-header-cell>>

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.scss
@@ -8,6 +8,7 @@ mat-card-title {
 
 #cluster-summary-row {
   mat-card {
+    margin: 10px 5px 0 5px;  // set to match legacy margins
     height: 80%;
 
     .label {
@@ -29,7 +30,8 @@ mat-card-title {
 
 #cluster-graphs-row {
   mat-card {
-    //padding: 16px 8px;  // use px instead of em b/c used in calculating graph size
+    margin: 10px 5px 0 5px;  // set to match legacy margins
+
     mat-card-content {
       margin: 6px 16px 16px 6px !important;
       padding: unset;
@@ -43,6 +45,7 @@ mat-card-title {
 
 #cluster-vulnerability-table-row {
   mat-card {
+    margin: 10px 5px 0 5px;  // set to match legacy margins
     mat-table {
       min-width: 500px;
 
@@ -54,6 +57,7 @@ mat-card-title {
 }
 
 #cluster-events-row {
+  margin: 10px 5px 0 5px;  // set to match legacy margins
   // top right bottom left
   padding: 0 0 0 0;
   height: 12em;

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
@@ -1,34 +1,32 @@
 <div class="page-container">
   <div class="page-container-content">
-    <div class="image-scan-list" *ngIf="dataSource">
-      <mat-toolbar>
-        <mat-toolbar-row>
-          <div class="col-lg-9 col-xs-12">
-            <span class="page-title" [matTooltip]="dataSource.url + '/' + dataSource.name + ':' + dataSource.tag" >Image: {{dataSource.name+':'+dataSource.tag}}</span>
+    <mat-card class="image-scan-list" *ngIf="dataSource">
+      <div class="row header-row">
+        <div class="col-lg-9 col-xs-12">
+          <span id="image-name" [matTooltip]="dataSource.url + '/' + dataSource.name + ':' + dataSource.tag" >Image: {{dataSource.name+':'+dataSource.tag}}</span>
+        </div>
+        <div class="col-lg-2 col-lg-offset-1 col-xs-12">
+          <div class="mr-15px">
+            <mat-spinner *ngIf="displayImageScanSpinner$ | async" [diameter]="30"></mat-spinner>
           </div>
-          <div class="col-lg-2 col-lg-offset-1 col-xs-12">
-            <div class="mr-15px">
-              <mat-spinner *ngIf="displayImageScanSpinner$ | async" [diameter]="30"></mat-spinner>
-            </div>
-            <a color="primary" *ngIf="dataSource || !dataSource" mat-raised-button [disabled]="displayImageScanSpinner$ | async" (click)="scanImage()">{{ scanButtonText }}</a>
-          </div>
-        </mat-toolbar-row>
-        <mat-toolbar-row class="image-id-row">
-          <div class="col-xs-12">
-            <span [matTooltip]="dataSource.dockerImageId"
-                  matTooltipClass="image-id-tooltip"
-            >Image ID: {{dataSource.dockerImageId.length > 15 ?
-              dataSource.dockerImageId.substring(0, 15) + '...' : dataSource.dockerImageId}}</span>
-          </div>
-        </mat-toolbar-row>
-      </mat-toolbar>
-      <div class="mat-elevation-z8 image-details">
+          <a color="primary" *ngIf="dataSource || !dataSource" mat-raised-button [disabled]="displayImageScanSpinner$ | async" (click)="scanImage()">{{ scanButtonText }}</a>
+        </div>
+      </div>
+      <div class="row header-row image-id-row">
+        <div class="col-xs-12">
+          <span [matTooltip]="dataSource.dockerImageId"
+                matTooltipClass="image-id-tooltip"
+          >Image ID: {{dataSource.dockerImageId.length > 15 ?
+            dataSource.dockerImageId.substring(0, 15) + '...' : dataSource.dockerImageId}}</span>
+        </div>
+      </div>
+      <div class="image-details">
         <div class="left-elements">
-          <div class="elements">
+          <div class="elements" style="min-width: 110px;">
             <p>Scan Result</p>
             <p class="first-element-content" [ngStyle]="{'color': scanResultTextColor}">{{scanResultText}}</p>
           </div>
-          <div class="elements">
+          <div class="elements" style="min-width: 160px;">
             <p>Last Scanned</p>
             <div *ngIf="dataSource.lastScanned; else elseBlock">
               <p>{{dataSource.lastScanned | date: 'MM/dd/yyyy hh:mma'}}</p>
@@ -65,61 +63,63 @@
           </div>
         </div>
       </div>
-    </div>
-    <div class="scanner-error mat-elevation-z8" *ngIf="lastScanReport?.encounterError">
+    </mat-card>
+    <mat-card class="scanner-error" *ngIf="lastScanReport?.encounterError">
       <h3 class="error-msg" style="margin: unset; padding: 5px 10px;">Error</h3>
       <div [innerHTML]="lastScanReport?.summary" class="error-msg"></div>
-    </div>
-    <div class="image-scan-result-list" *ngIf="displayComplianceAndIssueTable">
-      <mat-toolbar>
-        <span class="subnav-title" matTooltip="Scanner Compliance Report">Scanner Compliance Report</span>
-        <div class="advanced-search" *ngIf="imageScanDates">
+    </mat-card>
+    <mat-card class="image-scan-result-list scrollable-table-card" *ngIf="displayComplianceAndIssueTable">
+      <div class="row header-row">
+        <div class="col-xs-12 col-sm-9 col-lg-10" id="compliance-report-title">
+          <span matTooltip="Scanner Compliance Report">Scanner Compliance Report</span>
+        </div>
+        <div class="col-xs-10 col-sm-3 col-lg-2 advanced-search" id="compliance-report-buttons" *ngIf="imageScanDates">
           <mat-select [formControl]="scanDateDefault" (selectionChange)="onChangeScanDate($event)" class="title-font ">
             <mat-option *ngFor="let scanDate of imageScanDates" [value]="scanDate.created_at"> {{scanDate.created_at | date: 'MM/dd/yyyy hh:mma'}}</mat-option>
           </mat-select>
         </div>
-      </mat-toolbar>
-      <div class="mat-elevation-z8">
-        <table mat-table [dataSource]="scannerComplianceReport" #complianceSort="matSort" matSort  matSortActive="policy" matSortDisableClear matSortDirection="asc">
+      </div>
+      <div class="table-wrapper">
+        <mat-table [dataSource]="scannerComplianceReport" #complianceSort="matSort" matSort  matSortActive="policy" matSortDisableClear matSortDirection="asc">
           <ng-container matColumnDef="policy">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Policy</th>
-            <td mat-cell *matCellDef="let result"> {{result.policyName}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear>Policy</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.policyName}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="status">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Passed/Failed</th>
-            <td mat-cell *matCellDef="let result">  {{result.policyStatus ? 'Passed' : 'Failed' }} </td>
-          </ng-container>
-          <ng-container matColumnDef="required">
-            <th mat-header-cell *matHeaderCellDef> Required</th>
-            <td mat-cell *matCellDef="let result"> {{result.policyRequirement ? 'Yes' : 'No' }} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Passed/Failed</mat-header-cell>
+            <mat-cell *matCellDef="let result">  {{result.policyStatus ? 'Passed' : 'Failed' }} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="compliant">
-            <th mat-header-cell *matHeaderCellDef > Compliant</th>
-            <td mat-cell *matCellDef="let result"> {{result.policyStatus ? 'Yes' : 'No'}} </td>
+            <mat-header-cell *matHeaderCellDef > Compliant</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.policyStatus ? 'Yes' : 'No'}} </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="required">
+            <mat-header-cell *matHeaderCellDef> Required</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.policyRequirement ? 'Yes' : 'No' }} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="critical_issues">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Critical</th>
-            <td mat-cell *matCellDef="let result"> {{result.criticalIssues}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Critical</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.criticalIssues}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="major_issues">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Major</th>
-            <td mat-cell *matCellDef="let result"> {{result.majorIssues}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Major</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.majorIssues}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="medium_issues" >
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Medium</th>
-            <td mat-cell *matCellDef="let result"> {{result.mediumIssues}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Medium</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.mediumIssues}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="low_issues">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Low</th>
-            <td mat-cell *matCellDef="let result" > {{result.lowIssues}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Low</mat-header-cell>
+            <mat-cell *matCellDef="let result" > {{result.lowIssues}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="negligible_issues">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Negl</th>
-            <td mat-cell *matCellDef="let result"> {{result.negligibleIssues}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Negl</mat-header-cell>
+            <mat-cell *matCellDef="let result"> {{result.negligibleIssues}} </mat-cell>
           </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="getIssuesByPolicy(row)" class="table-row"></tr>
-        </table>
+          <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="getIssuesByPolicy(row)" class="table-row"></mat-row>
+        </mat-table>
       </div>
       <mat-paginator
         [length]="totalCount"
@@ -127,37 +127,43 @@
         [pageSizeOptions]="[10, 20, 50, 100, 200, 500, 1000]"
         (page)="scannerPageEvent($event)"
         showFirstLastButtons #compliancePaginator></mat-paginator>
-    </div>
-    <div class="issues-list" *ngIf="displayComplianceAndIssueTable">
-      <mat-toolbar>
-        <div class="col-sm-3 no-padding">
-          <span class="subnav-title">Issues</span>
+    </mat-card>
+    <mat-card class="issues-list scrollable-table-card" *ngIf="displayComplianceAndIssueTable">
+      <div class="row header-row">
+        <div class="col-xs-9 col-sm-3" id="issues-title">
+          <span matTooltip="Scanner Compliance Report">Issues</span>
         </div>
-        <div class="col-sm-9 page-card-title-button-group-right-align">
+        <div class="col-xs-3 col-sm-9" id="issues-buttons">
           <button mat-icon-button (click)="downloadCsv()"><mat-icon>download</mat-icon></button>
         </div>
-      </mat-toolbar>
-      <div class="mat-elevation-z8">
-        <table mat-table [dataSource]="imageScanResultIssueData" #issueSort="matSort" matSort matSortActive="severity" matSortDisableClear matSortDirection="desc">
+      </div>
+      <div class="table-wrapper">
+        <mat-table [dataSource]="imageScanResultIssueData" #issueSort="matSort" matSort matSortActive="severity" matSortDisableClear matSortDirection="desc">
           <ng-container matColumnDef="scanner">
-            <th style="width: 3%;" mat-header-cell *matHeaderCellDef mat-sort-header="scanner" disableClear> Scanner</th>
-            <td style="width: 3%;" mat-cell *matCellDef="let issue"> {{issue.scannerName}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header="scanner" disableClear> Scanner</mat-header-cell>
+            <mat-cell *matCellDef="let issue"> {{issue.scannerName}} </mat-cell>
           </ng-container>
-          <ng-container matColumnDef="name">
-            <th style="width: 23%;" mat-header-cell *matHeaderCellDef mat-sort-header="scanner_name" disableClear> Issue Title</th>
-            <td style="width: 23%;" mat-cell *matCellDef="let issue" [matTooltip]="issue.name">
-              {{issue.name}}
-            </td>
+          <ng-container matColumnDef="isCompliant">
+            <mat-header-cell *matHeaderCellDef mat-sort-header="required_for_compliance" disableClear> Compliant</mat-header-cell>
+            <mat-cell *matCellDef="let issue">
+              <div class="row">
+                <mat-checkbox disableRipple (click)="$event.preventDefault()" [checked]="issue.isCompliant" class="pad-right-5">
+                </mat-checkbox>
+                <div >
+                  <mat-icon style="margin-top: 8px" *ngIf="issue.complianceReason" [matTooltip]="issue.complianceReason">info</mat-icon>
+                </div>
+              </div>
+            </mat-cell>
           </ng-container>
           <ng-container matColumnDef="severity">
-            <th style="width: 5%;" mat-header-cell *matHeaderCellDef mat-sort-header="severity" disableClear> Severity </th>
-            <td style="width: 5%;" mat-cell *matCellDef="let issue"> {{issue.severity}} </td>
+            <mat-header-cell *matHeaderCellDef mat-sort-header="severity" disableClear> Severity </mat-header-cell>
+            <mat-cell *matCellDef="let issue"> {{issue.severity}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="type">
-            <th style="width: 20%;" mat-header-cell *matHeaderCellDef mat-sort-header="type" disableClear> Type </th>
-            <td style="width: 20%;" mat-cell *matCellDef="let issue">
+            <mat-header-cell *matHeaderCellDef mat-sort-header="type" disableClear> Type </mat-header-cell>
+            <mat-cell *matCellDef="let issue">
               <div class="row">
-                <div class="col type-margin">
+                <div class="col-xs-8">
                   <ng-container *ngIf="issue.vulnerabilityDescUrl">
                     <a [href]="issue.vulnerabilityDescUrl" target="_blank"> {{issue.type}} </a>
                   </ng-container>
@@ -165,69 +171,64 @@
                     {{issue.type}}
                   </ng-container>
                 </div>
-                <div class="col">
+                <div class="col-xs-4">
                   <button mat-icon-button (click)="searchCVE(issue.type)">
                     <mat-icon>search</mat-icon>
                   </button>
                 </div>
               </div>
-
-
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="isCompliant">
-            <th style="width: 10%;" mat-header-cell *matHeaderCellDef mat-sort-header="required_for_compliance" disableClear> Compliant</th>
-            <td style="width: 10%;" mat-cell *matCellDef="let issue">
-              <div class="row pad-left-20">
-                <mat-checkbox disableRipple (click)="$event.preventDefault()" [checked]="issue.isCompliant" class="pad-right-5">
-                </mat-checkbox>
-                <div >
-                <mat-icon style="margin-top: 8px" *ngIf="issue.complianceReason" [matTooltip]="issue.complianceReason">info</mat-icon>
-                </div>
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="isFixable" >
-            <th style="width: 25%;" mat-header-cell *matHeaderCellDef mat-sort-header="is_fixable" disableClear> Fixable </th>
-            <td style="width: 25%;" mat-cell *matCellDef="let issue">
-              <mat-checkbox  disableRipple (click)="$event.preventDefault()"  [checked]="issue.isFixable"></mat-checkbox>
-              <span *ngIf="issue.isFixable"> ({{ issue.fixedVersion ? issue.fixedVersion : 'N/A' }})</span>
-            </td>
+            </mat-cell>
           </ng-container>
           <ng-container matColumnDef="packageName">
-            <th style="width: 3%;" mat-header-cell *matHeaderCellDef mat-sort-header="package_name" disableClear> Package </th>
-            <td style="width: 3%;" mat-cell *matCellDef="let issue" [matTooltip]="issue.packageName">
+            <mat-header-cell *matHeaderCellDef mat-sort-header="package_name" disableClear> Package </mat-header-cell>
+            <mat-cell *matCellDef="let issue" [matTooltip]="issue.packageName">
               {{ issue.packageName ? issue.packageName : 'N/A' }}
-            </td>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="name">
+            <mat-header-cell *matHeaderCellDef mat-sort-header="scanner_name" disableClear> Issue Title</mat-header-cell>
+            <mat-cell *matCellDef="let issue" [matTooltip]="issue.name">
+              {{issue.name}}
+            </mat-cell>
           </ng-container>
           <ng-container matColumnDef="installedVersion">
-            <th style="width: 5%;" mat-header-cell *matHeaderCellDef mat-sort-header="installed_version" disableClear> Installed </th>
-            <td style="width: 5%;" mat-cell *matCellDef="let issue" [matTooltip]="issue.installedVersion">
+            <mat-header-cell *matHeaderCellDef mat-sort-header="installed_version" disableClear> Installed </mat-header-cell>
+            <mat-cell *matCellDef="let issue" [matTooltip]="issue.installedVersion">
               {{ issue.installedVersion ? issue.installedVersion : 'N/A' }}
-            </td>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="isFixable" >
+            <mat-header-cell *matHeaderCellDef mat-sort-header="is_fixable" disableClear> Fixable </mat-header-cell>
+            <mat-cell *matCellDef="let issue">
+              <mat-checkbox  disableRipple (click)="$event.preventDefault()"  [checked]="issue.isFixable"></mat-checkbox>
+              <span *ngIf="issue.isFixable"> ({{ issue.fixedVersion ? issue.fixedVersion : 'N/A' }})</span>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="more">
+            <mat-header-cell matSort="false" *matHeaderCellDef disableClear></mat-header-cell>
+            <mat-cell *matCellDef="let issue">
+              <button mat-raised-button color="primary"
+                      id="details-button"
+                      (click)="showMoreIssueDetails(issue)"
+              >Details</button>
+              <button color="accent" id="request-exception-button" mat-raised-button *ngIf="issue.isFixable"
+                      [routerLink]="['/private', 'exceptions','create']"
+                      [queryParams]="{clusterId: clusterId, scannerId: issue.scannerId, cve: issue.type, policyIds: policyIds, namespaces: imageNamespaces, imageName: dataSource.url + '/' + dataSource.name  }"
+              > Request Exception</button>
+            </mat-cell>
           </ng-container>
 <!--          <ng-container matColumnDef="request_exception">-->
-<!--            <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Request Exception </th>-->
-<!--            <td mat-cell *matCellDef="let issue">-->
+<!--            <mat-header-cell *matHeaderCellDef mat-sort-header disableClear> Request Exception </th>-->
+<!--            <mat-cell *matCellDef="let issue">-->
 <!--              <a color="primary" mat-raised-button *ngIf="issue.isFixable"-->
 <!--                 [routerLink]="['/private', 'exceptions','create']"-->
 <!--                 [queryParams]="{clusterId: clusterId, scannerId: issue.scannerId, cve: issue.type, policyIds: policyIds, namespaces: imageNamespaces, imageName: dataSource.url + '/' + dataSource.name  }"-->
 <!--              > Request Exception</a>-->
-<!--            </td>-->
+<!--            </mat-cell>-->
 <!--          </ng-container>-->
-          <ng-container matColumnDef="more">
-            <th style="width: 8%;" mat-header-cell matSort="false" *matHeaderCellDef disableClear></th>
-            <td style="width: 8%;" mat-cell *matCellDef="let issue">
-              <a mat-button (click)="showMoreIssueDetails(issue)">+more</a>
-              <button color="primary" class="request-exception-button" mat-raised-button *ngIf="issue.isFixable"
-                 [routerLink]="['/private', 'exceptions','create']"
-                 [queryParams]="{clusterId: clusterId, scannerId: issue.scannerId, cve: issue.type, policyIds: policyIds, namespaces: imageNamespaces, imageName: dataSource.url + '/' + dataSource.name  }"
-              > Request Exception</button>
-            </td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="issuesDisplayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: issuesDisplayedColumns;"></tr>
-        </table>
+          <mat-header-row *matHeaderRowDef="issuesDisplayedColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: issuesDisplayedColumns;"></mat-row>
+        </mat-table>
       </div>
       <mat-paginator
         [length]="totalImageScanResultData"
@@ -235,7 +236,7 @@
         [pageSizeOptions]="[10, 20, 50, 100, 200, 500, 1000]"
         (page)="pageIssues($event)"
         showFirstLastButtons #issuePaginator></mat-paginator>
-    </div>
+    </mat-card>
   </div>
 </div>
 

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.scss
@@ -1,6 +1,8 @@
+@use '@angular/material' as mat;
+
 .scanner-error {
   width: 99.5%;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   border: red 1px solid;
   background: white;
   text-transform: capitalize;
@@ -10,53 +12,47 @@
   }
 }
 
+mat-card {
+  margin-bottom: 20px;
+}
+
+/*
+align-self: center;
+justify-self: center;
+align-content: center;
+justify-content: center;
+align-items: center;
+justify-items: center;
+text-align: center;
+vertical-align: middle;
+*/
+
+.header-row {
+  margin: 0;
+
+  div {
+    min-height: 58px;
+    display: flex;
+    align-items: center;
+  }
+}
+
 .image-scan-list {
   flex: 3;
   width: 99.5%;
-  padding-bottom: 20px;
 
-  > mat-toolbar {
-    padding-bottom: 10px;
-    @media all and (max-width: 850px) {
-      height: fit-content;
-      display: flex;
-      flex-direction: column;
-      flex-wrap: wrap;
-      //padding-bottom: 80px;
-    }
-
-    .mat-toolbar-row {
-      width: 100%;
-      flex-wrap: wrap;
-      padding-left: 0;
-
-      &.image-id-row {
-        height: 20%;
-        font-weight: normal;
-        font-size: 15px;
-      }
-
-      .col-lg-9 {
-        align-items: center;
-        display: flex;
-        min-width: 0px;
-      }
-
-      .col-lg-2 {
-        display: flex;
-        margin-left: auto;
-        padding: 0px;
-        flex-basis: auto;
-      }
-    }
+  #image-name{
+    font-size: 26px;
+    text-wrap: initial;
   }
 
   .image-details {
+    background-color: mat.get-color-from-palette(mat.$gray-palette, 300);
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     @media all and (max-width: 1186px) {
-      overflow-x: scroll;
+      overflow-x: auto;
     }
 
     .left-elements {
@@ -66,11 +62,7 @@
       .elements {
         display: flex;
         flex-direction: column;
-        margin: 10px 50px 0 15px;
-
-        .first-element-content {
-          color: green;
-        }
+        margin: 10px 30px 0 15px;
       }
     }
 
@@ -93,114 +85,120 @@
   flex: 3;
   width: 99.5%;
 
-  > mat-toolbar {
-    @media all and (max-width: 850px) {
-      display: flex;
-      flex-direction: column;
-    }
-
-    .image-subnav-title {
-      @media all and (max-width: 850px) {
-        width: 250px;
-        white-space: nowrap;
-      }
-      @media all and (max-width: 377px) {
-        width: 100px;
-        white-space: nowrap;
-      }
+  #compliance-report-title {
+    span {
+      font-size: 26px;
+      font-weight: normal;
     }
   }
+  #compliance-report-buttons {}
 
-  div.mat-elevation-z8 {
-    overflow-x: auto;
-    @media all and (max-width: 685px) {
-      overflow-x: scroll;
-    }
+  .mat-column-policy {
+    min-width: 150px;
+  }
+  .mat-column-status {
+    min-width: 70px;
+  }
+  .mat-column-compliant {
+    max-width: 150px;
+    min-width: 85px;
+  }
+  .mat-column-required {
+    max-width: 150px;
+    min-width: 75px;
+  }
+
+  .mat-column-critical_issues, .mat-column-major_issues,
+  .mat-column-medium_issues, .mat-column-low_issues,
+  .mat-column-negligible_issues {
+    min-width: 50px;
+    max-width: 100px;
   }
 }
 
 .issues-list {
   width: 99.5%;
   overflow-x: auto;
-  // try setting min widths with percentages
- /*
-  .mat-column-scanner {
-    width: 10%;
-    padding-right: 5px;
+
+  #issues-title {
+    span {
+      font-size: 26px;
+      font-weight: normal;
+    }
+  }
+  #issues-buttons {
+    justify-content: end;
   }
 
-  .mat-column-scanner_name {
-    width: 60%;
-    padding-right: 5px;
+  .mat-column-scanner {
+    min-width: 100px;
+    max-width: 150px;
+  }
+
+  .mat-column-isCompliant {
+    min-width: 100px;
+    max-width: 150px;
   }
 
   .mat-column-severity {
-    width: 5%;
-    padding-right: 5px;
+    min-width: 75px;
+    max-width: 100px;
   }
 
   .mat-column-type {
-    width: 15%;
-    padding-right: 5px;
-  }
-
-  .mat-column-required_for_compliance {
-    width: 5%;
-  }
-
-  .mat-column-is_fixable {
-    width: 5%;
-  }
-
-  */
-
-  div.mat-elevation-z8 {
-    overflow-x: auto;
-    @media all and (max-width: 685px) {
-      overflow-x: scroll;
+    min-width: 185px;
+    max-width: 250px;
+    .col-xs-8 {
+      display: flex;
+      align-self: center;
+      padding-right: 0;
+    }
+    .col-xs-4 {
+      padding-left: 0;
     }
   }
+
+  .mat-column-packageName {
+    min-width: 150px;
+    max-width: 200px;
+  }
+
+  .mat-column-name {
+    min-width: 250px;
+  }
+
+  .mat-column-installedVersion {
+    min-width: 80px;
+    max-width: 100px;
+  }
+
+  .mat-column-isFixable {
+    min-width: 130px;
+    .row {
+      margin: 0;
+    }
+  }
+
+  .mat-column-more {
+    min-width: 280px;
+  }
+
+  .mat-column-request_exception {}
+
+  #details-button {
+    min-width: 80px;
+    margin-right: 0.25em;
+  }
+
+  #request-exception-button {
+    min-width: 155px;
+    margin-left: 0.25em;
+  }
+
 }
 
-.advanced-search {
-  flex: 1 1 auto;
-  text-align: end;
-}
-
-mat-icon-button {
-  margin-left: 5px;
-}
-
-.mr-15px {
-  margin-right: 15px;
-}
 
 /*TODO(mdc-migration): The following rule targets internal classes of paginator that may no longer apply for the MDC version.*/
 mat-paginator {
   padding-top: 10px;
-}
-
-.pad-left-20 {
-  padding-left: 20px;
-}
-
-.pad-right-5 {
-  padding-right: 5px;
-}
-
-
-.type-margin {
-  margin-top: 20px;
-
-}
-
-.request-exception-button {
-  display: inline-block;
-  white-space: nowrap;
-  text-decoration: none;
-  vertical-align: baseline;
-  text-align: center;
-  margin: 0;
-  min-width: 64px;
-  line-height: 36px;
 }

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.ts
@@ -35,7 +35,8 @@ export class ImageScanResultComponent implements OnInit, AfterViewInit, OnDestro
     'major_issues',
     'medium_issues',
     'low_issues',
-    'negligible_issues'];
+    'negligible_issues'
+  ];
   issuesDisplayedColumns: string[] = [
     'scanner',
     'isCompliant',

--- a/dash/frontend/src/app/modules/private/pages/image/images-list/image.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/images-list/image.component.html
@@ -8,7 +8,7 @@
           </button>
         </div>
       </div>
-      <div class="page-button-spacing flex-display">
+      <div class="page-button-spacing flex-display" id="images-buttons">
         <mat-form-field class="mr-10px search-image">
           <mat-label>Search image</mat-label>
           <input #imageInput matInput autocomplete="off" type="search" value="{{searchTerm}}"/>
@@ -18,7 +18,7 @@
         </button> &nbsp;
         <button
           class="scan-displayed-images-button"
-          [style.display]="(userIsAdmin)? 'block': 'none'"
+          *ngIf="userIsAdmin"
           [disabled]="!(dataSource && dataSource.data)"
           (click)="openConfirmScanDialog()"
           mat-raised-button
@@ -27,9 +27,9 @@
         </button>
       </div>
     </div>
-    <mat-card appearance="outlined">
-      <div class="page-table">
-        <table mat-table [dataSource]="dataSource" matSort  matSortActive="date" matSortDisableClear matSortDirection="desc">
+    <mat-card class="scrollable-table-card">
+      <div class="table-wrapper">
+        <mat-table [dataSource]="dataSource" matSort  matSortActive="date" matSortDisableClear matSortDirection="desc">
           <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef mat-sort-header disableClear>Name and Tag</mat-header-cell>
             <mat-cell *matCellDef="let image"> {{image.url + '/' + image.name + ':' + image.tag}} </mat-cell>
@@ -76,7 +76,7 @@
           <mat-row *matRowDef="let row; columns: displayedColumns;"
                    (click)="getImageScannerDetails(row)" class="table-row">
           </mat-row>
-        </table>
+        </mat-table>
       </div>
       <div class="paginator">
         <mat-paginator [length]="totalCount"

--- a/dash/frontend/src/app/modules/private/pages/image/images-list/image.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/image/images-list/image.component.scss
@@ -2,6 +2,10 @@
   height: unset;
 }
 
+#images-buttons {
+  align-items: center;
+}
+
 .scan-images-button {
   height: 40px;
   width: 80%;
@@ -21,7 +25,7 @@
 }
 
 .search-image {
-  margin-top: -18px;
+  //margin-top: -18px;
 }
 
 @media all and (max-width: 765px) {
@@ -55,25 +59,34 @@
 }
 
 // table column specifics
- .mat-column-date {
-  width: 150px;
-  max-width: 150px;
+.mat-column-name {
+  min-width: 400px;
 }
 
- .mat-column-runningCluster {
-  width: 120px;
+.mat-column-date {
+  //width: 150px;
+  min-width: 140px;
+  max-width: 200px;
+}
+
+.mat-column-runningCluster {
+  //width: 120px;
+  min-width: 120px;
   max-width: 120px;
-  text-align: center;
+  //justify-content: center;
 }
 
- .mat-column-scanResult {
-  width: 100px;
+.mat-column-scanResult {
+  //width: 100px;
+  min-width: 110px;
+  max-width: 135px;
+  //justify-content: center;
+}
+
+.mat-column-Crt,  .mat-column-Maj,  .mat-column-Med,  .mat-column-Min,  .mat-column-Neg {
+  min-width: 50px;
   max-width: 100px;
-  text-align: center;
-}
-
- .mat-column-Crt,  .mat-column-Maj,  .mat-column-Med,  .mat-column-Min,  .mat-column-Neg {
-  width: 50px;
-  max-width: 50px;
-  text-align: center;
+  //width: 50px;
+  //max-width: 50px;
+  justify-content: center;
 }

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -286,7 +286,7 @@ app-private {
     font-weight: bold;
   }
   mat-header-cell {
-    font-weight: 550;
+    font-weight: 550 !important;
   }
   mat-card-header {}
   mat-card-content {}
@@ -582,11 +582,6 @@ mat-form-field {
 .mat-column-image {
   word-break: break-all;
   padding-right: 10px
-}
-
-.mat-column-type {
-  word-break: break-all;
-  margin-right: 10px;
 }
 
 .mat-column-package {

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -51,9 +51,6 @@ $ms-default-theme: mat.define-light-theme((
 @import './app/modules/private/pages/audit-log/audit-log-list/audit-log.component.theme';
 
 mat-card {
-  margin: 10px 5px 0 5px;  // set to match legacy margins
-  //padding: 0 10px;
-
   mat-card-title {
     font-weight: bold;
   }


### PR DESCRIPTION
- Image Scan Results page
   - Use standard mat components (mat-table, mat-card)
   - Use row & column classes for headers (page & card)
- Image List page
   - Line up card with page header
   - Use row & column classes for page header
   - Align button text
   - Resize table columns (set min- & max-widths)
   - Pull off some unnecessary styling
- Cluster List dash:
   - set reasonable initial chart sized