### PR TITLE
Kube Bench Test Results Cleanup

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.html
@@ -3,7 +3,7 @@
     <div class="page-title">
       Kube Bench Test Results
     </div>
-    <div *ngIf="report && report.Totals" style="font-weight: bold; margin-bottom: 1em;">
+    <div *ngIf="report && report.Totals" class="page-subtitle">
       {{report.Totals.total_pass}}/{{report.Totals.total_pass + report.Totals.total_fail + report.Totals.total_warn}} Tests Passed
     </div>
 
@@ -13,8 +13,7 @@
 
     <div *ngIf="report && report.Controls">
       <mat-accordion *ngFor="let section of report.Controls" multi class="control-accordions">
-        <div>
-          <mat-expansion-panel>
+          <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header>
               <mat-panel-title>
                 {{section.id}}
@@ -94,7 +93,6 @@
               </mat-expansion-panel>
             </mat-accordion>
           </mat-expansion-panel>
-        </div>
       </mat-accordion>
     </div>
 

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.html
@@ -1,83 +1,101 @@
 <div class="page-container">
   <div class="page-container-content">
-    <div class="page-title-button-group-spacing">
-      <div class="page-title">
-        Kube Bench Test Results
-      </div>
-      <div *ngIf="report && report.Totals">
-        <div class="page-title">
-          {{report.Totals.total_pass}}/{{report.Totals.total_pass + report.Totals.total_fail + report.Totals.total_warn}} Tests Passed
-        </div>
-      </div>
+    <div class="page-title">
+      Kube Bench Test Results
+    </div>
+    <div *ngIf="report && report.Totals" style="font-weight: bold; margin-bottom: 1em;">
+      {{report.Totals.total_pass}}/{{report.Totals.total_pass + report.Totals.total_fail + report.Totals.total_warn}} Tests Passed
     </div>
 
-    <h3>
+    <div>
       Click on a test to learn more.
-    </h3>
+    </div>
 
-    <div class="page-card">
-      <ng-container *ngIf="report && report.Controls">
-        <div >
-          <div *ngFor="let section of report.Controls">
-            <h3>{{section.id}}: {{section.text}} ({{section.version}} v{{section.detected_version}})</h3>
+    <div *ngIf="report && report.Controls">
+      <mat-accordion *ngFor="let section of report.Controls" multi class="control-accordions">
+        <div>
+          <mat-expansion-panel>
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                {{section.id}}
+              </mat-panel-title>
+              <mat-panel-description>
+                {{section.text}} ({{section.version}} v{{section.detected_version}})
+              </mat-panel-description>
+            </mat-expansion-panel-header>
+            <mat-accordion *ngFor="let test of section.tests" multi class="test-accordions">
+              <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                  <mat-panel-title>
+                    {{test.section}}
+                  </mat-panel-title>
+                  <mat-panel-description>
+                    {{test.desc}}
+                  </mat-panel-description>
+                </mat-expansion-panel-header>
+                <mat-accordion *ngFor="let testResult of test.results" multi
+                               class="result-accordions" id="test-result-accordion">
+                  <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                      <mat-panel-title>
+                        {{testResult.test_number}}
+                      </mat-panel-title>
+                      <mat-panel-description>
+                        <span>
 
-            <div *ngFor="let test of section.tests">
-              <h4>{{test.section}}: {{test.desc}}</h4>
-
-              <mat-table
-                [dataSource]="test.results"
-                multiTemplateDataRows
-                class="mat-elevation-z8">
-                <ng-container matColumnDef="test">
-                  <mat-header-cell class="test-main" *matHeaderCellDef>Test</mat-header-cell>
-                  <mat-cell class="test-main" *matCellDef="let element"> {{element.test_number}} </mat-cell>
-                </ng-container>
-
-                <ng-container matColumnDef="description">
-                  <mat-header-cell class="test-description-main" *matHeaderCellDef>Test Description</mat-header-cell>
-                  <mat-cell *matCellDef="let element" class="test-description-main"> {{element.test_desc}} </mat-cell>
-                </ng-container>
-
-                <ng-container matColumnDef="pass/fail">
-                  <mat-header-cell class="pass-fail-main" *matHeaderCellDef>Pass/Fail</mat-header-cell>
-                  <mat-cell *matCellDef="let element" class="pass-fail-main">
-                    <ng-container *ngIf="element.status === 'PASS'">
-                      <div style="color: green">{{element.status}}</div>
-                    </ng-container>
-                    <ng-container *ngIf="element.status === 'FAIL'">
-                      <div style="color: red">{{element.status}}</div>
-                    </ng-container>
-                    <ng-container *ngIf="element.status === 'WARN'">
-                      <div style="color: orange">{{element.status}}</div>
-                    </ng-container>
-                  </mat-cell>
-                </ng-container>
-
-                <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->
-                <ng-container matColumnDef="expandedDetail">
-                  <mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
-                    <div class="expanded-information-row-div"
-                         [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
-
-                      <div class="covered-data"><b>Expected:</b> <br />{{element.expected_result === ""? "N/A" : element.expected_result}} </div>
-                      <div class="covered-data"><b>Actual:</b> <br />{{element.actual_value === ""? "N/A" : element.actual_value}} </div>
-                      <div class="covered-data"><b>Remediation:</b> <br />{{element.remediation === ""? "N/A" : element.remediation}} </div>
+                        </span>
+                        <span *ngIf="testResult.status === 'PASS'" style="color: green">
+                          {{testResult.status}}
+                        </span>
+                        <span *ngIf="testResult.status === 'FAIL'" style="color: red">
+                          {{testResult.status}}
+                        </span>
+                        <span *ngIf="testResult.status === 'WARN'" style="color: orange">
+                          {{testResult.status}}
+                        </span>
+                      </mat-panel-description>
+                    </mat-expansion-panel-header>
+                    <div class="row">
+                      <div class="col-xs-12 col-lg-3 test-details">
+                        <div class="test-details-title">
+                          Description:
+                        </div>
+                        <div class="test-details-content">
+                          {{ testResult.test_desc }}
+                        </div>
+                      </div>
+                      <div class="col-xs-12 col-lg-3 test-details">
+                        <div class="test-details-title">
+                          Expected:
+                        </div>
+                        <div class="test-details-content">
+                          {{ testResult.expected_result }}
+                        </div>
+                      </div>
+                      <div class="col-xs-12 col-lg-3 test-details">
+                        <div class="test-details-title">
+                          Actual:
+                        </div>
+                        <div class="test-details-content">
+                          {{ testResult.actual_value }}
+                        </div>
+                      </div>
+                      <div class="col-xs-12 col-lg-3 test-details">
+                        <div class="test-details-title">
+                          Remediation:
+                        </div>
+                        <div class="test-details-content">
+                          {{ testResult.remediation }}
+                        </div>
+                      </div>
                     </div>
-                  </mat-cell>
-                </ng-container>
-
-                <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-                <mat-row *matRowDef="let element; columns: displayedColumns;"
-                         class="table-row"
-                         [class.expanded-row]="expandedElement === element"
-                         (click)="expandedElement = expandedElement === element ? null : element">
-                </mat-row>
-                <mat-row *matRowDef="let row; columns: ['expandedDetail']" class="expanded-detail-row"></mat-row>
-              </mat-table>
-            </div>
-          </div>
+                  </mat-expansion-panel>
+                </mat-accordion>
+              </mat-expansion-panel>
+            </mat-accordion>
+          </mat-expansion-panel>
         </div>
-      </ng-container>
+      </mat-accordion>
     </div>
 
 

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
@@ -1,17 +1,14 @@
 .control-accordions {
 
+  > div > mat-expansion-panel {
+    margin-top: 1em;
+  }
+
   ::ng-deep
   .mat-expansion-panel-body {
     padding: 0 12px 16px;
   }
-  //> div {
-  //  max-width: 100%;
-  //  overflow-x: auto;
-  //
-  //  > mat-expansion-panel {
-  //    width: fit-content !important;
-  //  }
-  //}
+
   mat-panel-title {
     font-weight: bolder;
     font-size: 16px;

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
@@ -1,6 +1,11 @@
+.page-subtitle {
+  font-weight: bold;
+  margin-bottom: 1em;
+}
+
 .control-accordions {
 
-  > div > mat-expansion-panel {
+  > mat-expansion-panel {
     margin-top: 1em;
   }
 
@@ -44,7 +49,6 @@
 }
 
 .result-accordions {
-
   mat-panel-description {
     display: flex;
     justify-content: space-between;
@@ -57,7 +61,6 @@
 
   ::ng-deep
   .mat-expansion-panel-body {
-    //padding: 0 12px 16px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.scss
@@ -1,47 +1,78 @@
-.test-main {
-  max-width: 8%;
+.control-accordions {
+
+  ::ng-deep
+  .mat-expansion-panel-body {
+    padding: 0 12px 16px;
+  }
+  //> div {
+  //  max-width: 100%;
+  //  overflow-x: auto;
+  //
+  //  > mat-expansion-panel {
+  //    width: fit-content !important;
+  //  }
+  //}
+  mat-panel-title {
+    font-weight: bolder;
+    font-size: 16px;
+  }
+  mat-panel-description {
+    color: unset;
+    flex-grow: 8;
+  }
+
+  .test-accordions {
+    mat-expansion-panel {
+      box-shadow: unset;
+    }
+
+    // light borders (styled after mat-table borders)
+    mat-expansion-panel {
+      border-bottom: rgba(0, 0, 0, 0.12) solid 1px;
+
+      &.mat-expanded {
+        border: unset;
+        mat-expansion-panel-header {
+          border-bottom: rgba(0, 0, 0, 0.12) solid 1px;
+        }
+      }
+    }
+    .result-accordions mat-expansion-panel.mat-expanded {
+      border-bottom: rgba(0,0,0,0.12) solid 1px;
+      mat-expansion-panel-header {
+        border-bottom: unset;
+      }
+    }
+  }
 }
 
-.test-description-main {
-  min-width: 62%;
-  max-width: 62%;
-}
+.result-accordions {
 
-.pass-fail-main {
-  justify-content: flex-end;
-  max-width: 30%;
-}
+  mat-panel-description {
+    display: flex;
+    justify-content: space-between;
+  }
 
-.mat-mdc-row:not(.expanded-detail-row):hover {
-  background: whitesmoke;
-  cursor: pointer;
-}
+  ::ng-deep
+  .mat-expansion-panel-content {
+    padding: 0 24px;
+  }
 
-.expanded-detail-row:hover {
-  cursor: default;
-}
+  ::ng-deep
+  .mat-expansion-panel-body {
+    //padding: 0 12px 16px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 1em;
 
-.mat-mdc-row:not(.expanded-detail-row):active {
-  background: #efefef;
-}
+    .test-details {
+      line-break: anywhere;
+      margin-block: 0.25em;
 
-.mat-mdc-row td {
-  border-bottom-width: 0;
-  min-height: 0;
-}
-
-.expanded-detail-row {
-  min-height: 0;
-}
-
-.expanded-information-row-div {
-  overflow: hidden;
-  display: flex;
-  width: 100%;
-}
-
-.covered-data{
-  padding: 1%;
-  width: 32%;
-  font-size: 12px;
+      .test-details-title {
+        font-weight: bold;
+      }
+    }
+  }
 }

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.ts
@@ -9,19 +9,9 @@ import {IKubeBenchLog} from '../../../../../../core/entities/IKubeBenchReport';
   selector: 'app-kube-bench-report-details',
   templateUrl: './kube-bench-report-details.component.html',
   styleUrls: ['./kube-bench-report-details.component.scss'],
-  animations: [
-    trigger('detailExpand', [
-      state('collapsed', style({height: '0px', minHeight: '0'})),
-      state('expanded', style({height: '*'})),
-    transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
-])
-  ]
 })
 export class KubeBenchReportDetailsComponent implements OnInit {
-
-  displayedColumns = ['test', 'description', 'pass/fail'];
   id: number;
-  expandedElement: any | null;
   report: IKubeBenchLog;
 
   constructor(
@@ -36,6 +26,7 @@ export class KubeBenchReportDetailsComponent implements OnInit {
     this.kubeBenchService.getKubeBenchReportById(this.id)
       .pipe(take(1))
       .subscribe(rtrn => {
+        console.log({rtrn});
         this.report = rtrn.resultsJson;
     });
   }

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench-report-details/kube-bench-report-details.component.ts
@@ -26,7 +26,6 @@ export class KubeBenchReportDetailsComponent implements OnInit {
     this.kubeBenchService.getKubeBenchReportById(this.id)
       .pipe(take(1))
       .subscribe(rtrn => {
-        console.log({rtrn});
         this.report = rtrn.resultsJson;
     });
   }

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -289,7 +289,7 @@ app-private {
   mat-card-content {}
 }
 
-.page-card{
+.page-card {
   margin: 0;
   overflow-x: auto;
 }


### PR DESCRIPTION
This used to be a mat-table with a hand-coded "dropdown" intended to work like an accordion.
Now it's a bunch of nested accordions filled with the correct contents.

### Before
_(note that none of the elements are scrollable)_
Desktop:
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/0a1d351f-6c2d-4236-b70e-774a44110f23)

Mobile:
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/52b6e294-1055-472b-8a78-ca6b9c82aff9)
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/93fc72e2-1b4b-4421-941b-cfc6caacaed2)


### After
Desktop:
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/774613bc-2e00-4536-a45c-c55009806396)


Mobile:
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/a9f5651d-7898-468e-b513-02c1d68feaea)
![image](https://github.com/m9sweeper/m9sweeper/assets/50845926/6fa9aaff-8dd6-48c4-904e-3009980b159f)