### PR TITLE
Update KubSec, kube-bench, and GateKeeper versions

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.html
@@ -5,7 +5,7 @@
     </a>
 
     <div class="page-title-button-group-spacing">
-      <div class="padding-top-15">Run GateKeeper (3.9.2) using the following CLI command:</div>
+      <div class="padding-top-15">Install GateKeeper with the following command:</div>
       <div >
         <app-copy-to-clipboard-button
           successMessage="Command copied to clipboard!"
@@ -16,12 +16,34 @@
     </div>
 
     <div>
-      <textarea matInput [cdkTextareaAutosize]="true" #run class="code-snippet w-100 modal-content-left-align-no-margin modal-content-no-right-margin" readonly>helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
-    helm install gatekeeper/gatekeeper --name-template=gatekeeper --namespace gatekeeper-system --create-namespace --version 3.9.2
+      <textarea matInput [cdkTextareaAutosize]="true" #run class="code-snippet w-100 modal-content-left-align-no-margin modal-content-no-right-margin margin-top-1em" readonly>
+helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+helm install gatekeeper/gatekeeper --name-template=gatekeeper \
+    --namespace gatekeeper-system \
+    --create-namespace \
+    --version 3.12.0
       </textarea>
     </div>
 
-    <div>Note: Gatekeeper version v3.10 and newer is required for Kubernetes 1.24 and newer.</div>
+    <div class="padding-top-15">Note: You may need to adjust the GateKeeper version depending on your Kubernetes version.</div>
+    <div>
+        <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+            <!-- Kubernetes Version Column -->
+            <ng-container matColumnDef="k8sVersion">
+                <th mat-header-cell *matHeaderCellDef>Kubernetes Version</th>
+                <td mat-cell *matCellDef="let element">{{element.k8sVersion}}</td>
+            </ng-container>
+
+            <!-- Gatekeeper Version Columne -->
+            <ng-container matColumnDef="gatekeeperVersion">
+                <th mat-header-cell *matHeaderCellDef>Gatekeeper Version</th>
+                <td mat-cell *matCellDef="let element">{{element.gatekeeperVersion}}</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+    </div>
     <br>
     <div class="page-card-title-button-group-right-align">
       <button mat-raised-button matDialogClose color="primary">Done</button>

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.scss
@@ -2,3 +2,15 @@
   padding-top:15px;
 }
 
+.margin-top-1em {
+    margin-top: 1em;
+}
+
+table {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+th {
+    font-weight: bold;
+}

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-install-wizard-dialog/gate-keeper-install-wizard-dialog.component.ts
@@ -1,9 +1,24 @@
 import { Component } from '@angular/core';
 
+export interface GatekeeperVersionRow {
+  k8sVersion: string;
+  gatekeeperVersion: string;
+}
+
+const VERSION_DATA: GatekeeperVersionRow[] = [
+  { k8sVersion: 'v1.24.x - v1.27.x', gatekeeperVersion: 'v3.12.0' },
+  { k8sVersion: 'v1.22.x - v1.23.x', gatekeeperVersion: 'v3.11.0' },
+  { k8sVersion: 'v1.21.x', gatekeeperVersion: 'v3.10.0' },
+  { k8sVersion: 'v1.19.x - v1.20.x', gatekeeperVersion: 'v3.9.2' },
+  { k8sVersion: 'v1.16.x - v1.18.x', gatekeeperVersion: 'v3.7.2' }
+];
+
 @Component({
   selector: 'app-gate-keeper-install-wizard-dialog',
   templateUrl: './gate-keeper-install-wizard-dialog.component.html',
-  styleUrls: ['./gate-keeper-install-wizard-dialog.component.scss']
+  styleUrls: ['./gate-keeper-install-wizard-dialog.component.scss'],
 })
 export class GateKeeperInstallWizardDialogComponent {
+  displayedColumns: string[] = ['k8sVersion', 'gatekeeperVersion'];
+  dataSource = VERSION_DATA;
 }

--- a/manifests/charts/dash/values.yaml
+++ b/manifests/charts/dash/values.yaml
@@ -12,7 +12,7 @@ image:
 kubesec:
   registry: docker.io
   repository: kubesec/kubesec
-  tag: v2.12.0
+  tag: v2.13.0
   pullPolicy: Always
   credentials:
     create: false

--- a/manifests/charts/kube-bench/values.yaml
+++ b/manifests/charts/kube-bench/values.yaml
@@ -39,7 +39,7 @@ pod:
 
 image:
   repository: aquasec/kube-bench
-  tag: v0.6.11
+  tag: v0.6.17
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
### This updates the versions of KubeSec and kube-bench that is in the helm charts.
- KubeSec: v2.12.0 -> v2.13.0
- kube-bench: v0.6.11 -> v0.6.17

<br>

### This update also includes some changes to the GateKeeper installation dialog.
- Fixes some spacing issues
- Fixes the command formatting
- Adds a table that shows which version of GateKeeper to use for the different k8s versions.

![image](https://github.com/m9sweeper/m9sweeper/assets/6267549/2f69ff02-fa86-4bf3-9d48-1be08d15710b)

