### PR TITLE
UI Cleanup Tasks

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.html
@@ -1,23 +1,25 @@
 <!-- start of the upper part of the menu-->
 <div class="page-container">
   <div class="page-container-content">
-    <div class="page-title-button-group-spacing row">
-      <div class="col-md-6 col-xs-12 start-md center-xs cluster-group-name display-flex">
+    <div class="page-title-button-group-spacing row" id="clusterSummaryHeader">
+      <div class="col-md-6 col-xs-12 start-xs cluster-group-name display-flex">
         {{ clusterGroupName }}
         <button  [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" mat-icon-button  (click)="editClusterGroupNameDialog()">
           <mat-icon class="edit-cluster-group-icon">create</mat-icon>
         </button>
       </div>
-      <div class="col-md-6 col-xs-12 end-md center-xs display-flex">
+      <div class="col-md-4 col-xs-12 start-xs end-md display-flex middle-xs">
         <button
-          class="margin-right-10 margin-top-10"
+          class="margin-right-10"
           [allowedRoles]="['ADMIN', 'SUPER_ADMIN']"
           mat-raised-button
           color="warn"
           [disabled]="!clustersList || clustersList.length || disableOnSearch"
           (click)="deleteClusterGroup()">Delete Cluster Group</button>
+      </div>
+      <div class="col-md-2 col-xs-12 start-xs end-md display-flex middle-xs pt-xs-2 pt-md-0">
         <button
-          class="margin-right-10 margin-top-10"
+          class="margin-right-10"
           [allowedRoles]="['ADMIN', 'SUPER_ADMIN']"
           mat-raised-button
           color="primary"
@@ -25,8 +27,8 @@
       </div>
     </div>
   <!-- start of the first row of graphs-->
-  <div class="row margin-top-10" *ngIf="clustersList && clustersList.length">
-    <div class="margin-top-10 no-padding no-margin full-height col-xs-12 col-md-6 col-lg-4">
+  <div class="row" id="clusterSummaryGraphs" *ngIf="clustersList && clustersList.length">
+    <div class="no-padding no-margin margin-top-10 full-height col-xs-12 col-md-6 col-lg-4">
       <mat-card class="overview-graph-card" id="complianceSummaryLineChartCard">
         <mat-card-title class="center-xs">Compliance Summary</mat-card-title>
         <mat-card-content>
@@ -71,7 +73,7 @@
       </mat-card>
     </div>
 
-    <div class="widget margin-top-10 no-padding no-margin full-height col-xs-12 col-md-6 col-lg-4">
+    <div class="no-padding no-margin margin-top-10 full-height col-xs-12 col-md-6 col-lg-4">
       <mat-card class="overview-graph-card" id="lineChartCard">
         <mat-card-title class="center-xs">Scan History</mat-card-title>
         <mat-card-content>

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.scss
@@ -1,10 +1,14 @@
+mat-card-title {
+  font-size: 18px !important;
+}
+
 .row {
   padding-left: 20px;
   padding-right: 20px;
 }
 
 mat-card.overview-graph-card {
-  margin: 10px 5px 0 5px;  // set to match legacy margins
+  margin: 0 5px 0 5px;  // set to match legacy margins
 
   mat-card-content {
     margin: 6px 16px 16px 6px !important;

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
@@ -16,7 +16,7 @@
         </mat-list-item>
       </div>
 
-      <mat-divider *ngIf="contentTriggerButtons.length" style="margin-top: 0.5em; margin-bottom: 0.5em;"></mat-divider>
+      <mat-divider *ngIf="contentTriggerButtons.length"></mat-divider>
 
       <div *ngFor="let menuItem of menuItems">
         <a mat-list-item

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.scss
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.scss
@@ -1,0 +1,3 @@
+#main-list {
+  padding-block: 0;
+}

--- a/dash/frontend/src/generic-styles.scss
+++ b/dash/frontend/src/generic-styles.scss
@@ -1,0 +1,117 @@
+/**
+This is where you can add generic styles that will be applied by screen size.
+We DO NOT want classes that will be specific for pages - only global classes.
+If you add the class to one section, please add a value to all.
+ex:
+.pt-xs-1 {
+  padding-top: 1em;
+}
+@media only screen and (min-width: 48em) {
+  .pt-sm-1 {
+    padding-top: 1em;
+  }
+}
+and so on for each media query size.
+
+Media query sizes are based on the sizes defined in npm flexboxgrid
+https://www.npmjs.com/package/flexboxgrid
+
+naming and spacing defaults are based on Bootstrap spacing
+exception: explicitly name sizes xs-lg; omit sizes xl & xxl
+https://getbootstrap.com/docs/5.2/utilities/spacing/
+0 - for classes that eliminate the margin or padding by setting it to 0
+1 - for classes that set the margin or padding to $spacer * .25
+2 - for classes that set the margin or padding to $spacer * .5
+3 - for classes that set the margin or padding to $spacer
+4 - for classes that set the margin or padding to $spacer * 1.5
+5 - for classes that set the margin or padding to $spacer * 3
+auto - for classes that set the margin to auto
+ */
+
+$spacer: 1em;  // aka 1 em
+
+// xs screen sizes
+.pt-xs-0 {
+  padding-top: 0;
+}
+.pt-xs-1 {
+  padding-top: ($spacer * 0.25);
+}
+.pt-xs-2 {
+  padding-top: ($spacer * 0.5);
+}
+.pt-xs-3 {
+  padding-top: ($spacer);
+}
+.pt-xs-4 {
+  padding-top: ($spacer * 1.5);
+}
+.pt-xs-5 {
+  padding-top: ($spacer * 3);
+}
+
+// sm screen sizes
+@media only screen and (min-width: 48em) {
+  .pt-sm-0 {
+    padding-top: 0;
+  }
+  .pt-sm-1 {
+    padding-top: ($spacer * 0.25);
+  }
+  .pt-sm-2 {
+    padding-top: ($spacer * 0.5);
+  }
+  .pt-sm-3 {
+    padding-top: ($spacer);
+  }
+  .pt-sm-4 {
+    padding-top: ($spacer * 1.5);
+  }
+  .pt-sm-5 {
+    padding-top: ($spacer * 3);
+  }
+}
+
+// md screen sizes
+@media only screen and (min-width: 62em) {
+  .pt-md-0 {
+    padding-top: 0;
+  }
+  .pt-md-1 {
+    padding-top: ($spacer * 0.25);
+  }
+  .pt-md-2 {
+    padding-top: ($spacer * 0.5);
+  }
+  .pt-md-3 {
+    padding-top: ($spacer);
+  }
+  .pt-md-4 {
+    padding-top: ($spacer * 1.5);
+  }
+  .pt-md-5 {
+    padding-top: ($spacer * 3);
+  }
+}
+
+// lg screen sizes
+@media only screen and (min-width: 75em) {
+  .pt-lg-0 {
+    padding-top: 0;
+  }
+  .pt-lg-1 {
+    padding-top: ($spacer * 0.25);
+  }
+  .pt-lg-2 {
+    padding-top: ($spacer * 0.5);
+  }
+  .pt-lg-3 {
+    padding-top: ($spacer);
+  }
+  .pt-lg-4 {
+    padding-top: ($spacer * 1.5);
+  }
+  .pt-lg-5 {
+    padding-top: ($spacer * 3);
+  }
+}

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -10,6 +10,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 @import 'flexboxgrid/css/flexboxgrid.min.css';
 @import 'codemirror/lib/codemirror';
 @import 'codemirror/theme/material';
+@import 'generic-styles';
 
 //Default theme
 $ms-default-primary: mat.define-palette(mat.$indigo-palette, 800, 300, 900);


### PR DESCRIPTION
This PR includes a new file titled `generic-styles.scss`.

It uses the media queries from flexboxgrid (which is what we use for existing flexbox layout classes) and the conventions defined by Bootstrap to allow us to create classes to apply styling by size.

This SHOULD NOT be used for element-specific styling or program styling. It is ONLY for generic classes like the ones currently included.

Examples of potential additions:
- mx-xs-3: apply 1em margins to the left and right of an element to all sizes equal to or greater than xs
- mb-md-2: apply 0.5em margins to the bottom of an element to all sizes equal to or greater than md (medium)