### PR TITLE
fix init job

### DIFF
--- a/dash/backend/src/modules/cluster/dao/cluster.dao.ts
+++ b/dash/backend/src/modules/cluster/dao/cluster.dao.ts
@@ -241,7 +241,7 @@ export class ClusterDao {
      */
     async seedInitialCluster(cluster, clusterGroupName: string, policy: PolicyDto, scanner: ScannerDto, userId: number) {
         const knex = await this.databaseService.getConnection();
-        return knex.transaction(async function(trx: Knex.Transaction) {
+        return knex.transaction(async (trx: Knex.Transaction) => {
                 this.logger.log({label: 'Saving initial cluster & cluster group', data: { cluster, clusterGroupName, userId }}, 'ClusterDao.seedInitialCluster');
 
                 const cgId = await trx('cluster_group')


### PR DESCRIPTION
Cause:
The logger service inside the function passed to the knex transaction didn't have 'this' in scope. Was previously not an issue because they were changed to use the logger service in a recent clean up.

Solution

Instead of using the 'function() {...}' syntax for the function passed in, use the '() => {...}' syntax as it preserves the context, and thus allows this.logger to be defined.