### PR TITLE
fix cluster sync job

### DIFF
--- a/dash/backend/src/modules/k8s-image/services/k8s-image.service.ts
+++ b/dash/backend/src/modules/k8s-image/services/k8s-image.service.ts
@@ -151,7 +151,7 @@ export class K8sImageService {
                         // new! create it!
                         const savedImage = await this.imageService.createImage(image, clusterId, false);
                         if (savedImage && savedImage.id) {
-                            imageIdMapRunningInCluster.setIdRunning(name, k8sImageDto.imageHash, existingImageDto.id);
+                            imageIdMapRunningInCluster.setIdRunning(name, k8sImageDto.imageHash, savedImage.id);
                             k8sImageDto.imageId = savedImage.id;
                             this.logger.log({label: 'New image added to index and scan queued', data: { name }}, 'K8sImageService.saveK8sImages');
                         }


### PR DESCRIPTION
Cause:

Was using existingImageDto.id rather than savedImaged.id when the sync job was trying to update a new image. Since this was in a code block only reachable if we didn't have existingImageDto, that was guaranteed to error out.