### PR TITLE
Cleanup kube-hunter page for no reports

### DIFF
--- a/dash/backend/package-lock.json
+++ b/dash/backend/package-lock.json
@@ -64,7 +64,6 @@
         "@nestjs/schematics": "^9.2.0",
         "@nestjs/testing": "^9.4.3",
         "@types/amqplib": "^0.10.1",
-        "@types/cron": "^2.0.1",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.3",
         "@types/multer": "^1.4.7",
@@ -2792,16 +2791,6 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
-    },
-    "node_modules/@types/cron": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.0.tgz",
-      "integrity": "sha512-5bBaAkqvSFBX8JMi/xCofNzG5E594TNsApMz68dLd/sQYz/HGQqgcxGHTRjOvD4G3Y+YF1Oo3S7QdCvKt1KAJQ==",
-      "deprecated": "This is a stub types definition. cron provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "cron": "*"
-      }
     },
     "node_modules/@types/ejs": {
       "version": "3.1.2",
@@ -25673,6 +25662,7 @@
       "dev": true
     },
     "vendor/nestjs-mailer": {
+      "name": "@nestjs-modules/mailer",
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {

--- a/dash/backend/package.json
+++ b/dash/backend/package.json
@@ -93,7 +93,6 @@
     "@nestjs/schematics": "^9.2.0",
     "@nestjs/testing": "^9.4.3",
     "@types/amqplib": "^0.10.1",
-    "@types/cron": "^2.0.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",
     "@types/multer": "^1.4.7",

--- a/dash/backend/src/modules/kube-hunter/dao/kube-hunter.dao.ts
+++ b/dash/backend/src/modules/kube-hunter/dao/kube-hunter.dao.ts
@@ -57,13 +57,13 @@ export class KubeHunterDao {
             .then(report => plainToInstance(KubeHunterDto, report));
     }
 
-    async countReport(clusterId:number): Promise<Number> {
+    async countReport(clusterId:number): Promise<number> {
         const knex = await this.databaseService.getConnection();
-        const result = await knex('kube_hunter as kh')
+        return knex('kube_hunter as kh')
+            .where('kh.cluster_id', clusterId)
             .count('kh.id', {as: 'count'})
-            .returning('count');
-
-        return (result && result[0] && result[0].count) ? result[0].count : 0;
+            .returning('count')
+            .then(res => res?.[0]?.count ? +res[0].count : 0);
     }
 
 }

--- a/dash/backend/src/modules/kube-hunter/service/kube-hunter.service.ts
+++ b/dash/backend/src/modules/kube-hunter/service/kube-hunter.service.ts
@@ -33,7 +33,7 @@ export class KubeHunterService {
         const reportCount =await this.kubeHunterDao.countReport(clusterId);
         return{
             list: list,
-            reportCount:+reportCount
+            reportCount: reportCount
         }
         //return await this.kubeHunterDao.getAllReportsForCluster(clusterId, page, limit);
     }

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter-dialog/kube-hunter-dialog.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter-dialog/kube-hunter-dialog.component.html
@@ -17,13 +17,14 @@
     <div class="modal-content-left-align-no-margin">
 
       <div *ngIf="cronjobOpt === false">
-        <div class="page-title-button-group-spacing">
-          <div > Run kube-hunter using the following CLI command:</div>
-          <div >
+        <div class="page-title-button-group-spacing align-items-center mb-xs-3">
+          <div> Run kube-hunter using the following CLI command:</div>
+          <div class="text-align-right">
             <app-copy-to-clipboard-button
               successMessage="Command copied to clipboard!"
               errorMessage="Command could not be copied."
               [text]="run.value"
+              [responsive]="true"
             ></app-copy-to-clipboard-button>
           </div>
         </div>
@@ -56,11 +57,12 @@
         </div>
         <br>
         <div *ngIf="cronjobTime">
-          <div class="page-title-button-group-spacing">
-            <div > Run kube-hunter using the following CLI command.</div>
-            <div ><app-copy-to-clipboard-button
+          <div class="page-title-button-group-spacing align-items-center mb-xs-3">
+            <div> Run kube-hunter using the following CLI command.</div>
+            <div class="text-align-right"><app-copy-to-clipboard-button
               successMessage="Command copied to clipboard!"
               errorMessage="Command could not be copied."
+              [responsive]="true"
               [text]="run.value"
             ></app-copy-to-clipboard-button>
             </div>

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter-dialog/kube-hunter-dialog.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter-dialog/kube-hunter-dialog.component.ts
@@ -18,12 +18,12 @@ export class KubeHunterDialogComponent implements OnInit {
 
   cronjobOpt = true;
   cronjobTime = 'daily';
-  isCompleted = true;
   backendUrl: string;
   clusterId: number;
   report: IKubeHunterReport;
   modalOpened = Date.now();
 
+  // IDE may suggest this is unused, but it is used in the HTML
   cronjobScheduleOpts = {
     weekly: '0 0 * * 0',
     daily: '0 0 * * *',

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
@@ -29,9 +29,9 @@
                 <th>High</th>
               </tr>
               <tr>
-                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.low : ''}}</td>
-                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.medium : ''}}</td>
-                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.high : ''}}</td>
+                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.low : 'N/A'}}</td>
+                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.medium : 'N/A'}}</td>
+                <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.high : 'N/A'}}</td>
               </tr>
             </table>
           </mat-card-content>
@@ -81,11 +81,11 @@
               <mat-table [dataSource]="dataSource">
                 <ng-container matColumnDef="date">
                   <mat-header-cell *matHeaderCellDef> Date </mat-header-cell>
-                  <mat-cell *matCellDef="let report"> {{report.date | date: 'M/dd/yyyy' }} </mat-cell>
+                  <mat-cell *matCellDef="let report"> {{report.createdAt | date: 'M/dd/yyyy' }} </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="time">
-                  <mat-header-cell *matHeaderCellDef> Time </mat-header-cell>\
-                  <mat-cell *matCellDef="let report"> {{report.date | date: 'mediumTime'}} </mat-cell>
+                  <mat-header-cell *matHeaderCellDef> Time </mat-header-cell>
+                  <mat-cell *matCellDef="let report"> {{report.createdAt | date: 'mediumTime'}} </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="numVulnerabilities">
                   <mat-header-cell *matHeaderCellDef> Number of Vulnerabilities </mat-header-cell>

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
@@ -28,7 +28,7 @@
                 <th>Medium</th>
                 <th>High</th>
               </tr>
-              <tr>
+              <tr *ngIf="receivedResponse">
                 <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.low : 'N/A'}}</td>
                 <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.medium : 'N/A'}}</td>
                 <td class="last-run-data">{{ scansExist ? mostRecentVulnerabilities.high : 'N/A'}}</td>

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.ts
@@ -19,7 +19,6 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
 
   private unsubscribe$ = new Subject<void>();
   clusterId: number;
-  daysPassed: number;
   allReportsForCluster: IKubeHunterReport[];
   scansExist = false;
   mostRecentVulnerabilities = {low: 0, medium: 0, high: 0};
@@ -64,42 +63,16 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
         take(1),
       )
       .subscribe(res => {
-        if (res.reportCount > 0) {
-          this.scansExist = true;
-          res.list.forEach(reports => {
-            reports.nodes = JSON.parse(reports.nodes);
-            reports.services = JSON.parse(reports.services);
-            reports.vulnerabilities = JSON.parse(reports.vulnerabilities);
-          });
-          this.allReportsForCluster = res.list;
-          if (res.list[0] != null){
-            this.daysPassed = Math.floor((Date.now() - res.list[0].createdAt) / (1000 * 60 * 60 * 24));
-            if (this.daysPassed >= 90) {
-              this.ourAdvice = 'It has been ' + this.daysPassed + ' days since you ran kube-hunter. You should run it again soon.';
-              this.penetrationTestStatusInvalid = true;
-              this.penetrationTestText = 'Report Outdated';
-            } else if (this.daysPassed >= 10) {
-              this.ourAdvice = 'It has been ' + this.daysPassed + ' days since you last ran kube-hunter.';
-              this.penetrationTestStatusInvalid = true;
-              this.penetrationTestText = 'Report Outdated';
-            } else {
-              this.ourAdvice = 'It has been ' + this.daysPassed + ' days since you last ran kube-hunter.';
-              this.penetrationTestStatusInvalid = false;
-              this.penetrationTestText = 'Report Valid';
-            }
-            res.list[0].vulnerabilities?.value?.value?.forEach( vulnerability => {
-              if (vulnerability.severity === 'low') {
-                this.mostRecentVulnerabilities.low += 1;
-              } else if (vulnerability.severity === 'medium') {
-                this.mostRecentVulnerabilities.medium += 1;
-              } else if (vulnerability.severity === 'high') {
-                this.mostRecentVulnerabilities.high += 1;
-              }
-            });
-          }
-          this.reportCount = res.reportCount;
-          this.populateTable();
-        }
+        this.scansExist = !!res?.list?.length;
+        this.allReportsForCluster = res?.list || [];
+        this.reportCount = res?.reportCount || 0;
+        res?.list?.forEach(reports => {
+          reports.nodes = JSON.parse(reports.nodes);
+          reports.services = JSON.parse(reports.services);
+          reports.vulnerabilities = JSON.parse(reports.vulnerabilities);
+        });
+        this.populateMessages(res?.list[0]);
+        this.populateTable();
       }, (e) => {
         if (e.status === 404) {
           this.ourAdvice = 'Run kube-hunter to find vulnerabilities within your cluster.';
@@ -110,9 +83,46 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
   }
 
   populateTable() {
-    this.allReportsForCluster?.forEach(reports => reports.date = new Date(+reports.createdAt).toLocaleString());
     this.dataSource = new MatTableDataSource(this.allReportsForCluster);
   }
+
+  populateMessages(recentScan: IKubeHunterReport): void {
+    // Reset vulnerability counts
+    this.mostRecentVulnerabilities.high = this.mostRecentVulnerabilities.medium
+      = this.mostRecentVulnerabilities.low = 1;
+
+    if (!recentScan) {
+      this.ourAdvice = 'Run kube-hunter to audit your cluster security';
+      this.penetrationTestText = 'Not yet run';
+      this.penetrationTestStatusInvalid = true;
+      return;
+    }
+    // Calculate the messaging for the penetration test status & Our advice column based on
+    // how long it has been since the most recent scan
+    const daysPassed = Math.floor((Date.now() - recentScan.createdAt) / (1000 * 60 * 60 * 24));
+    if (daysPassed >= 90) {
+      this.ourAdvice = 'It has been ' + daysPassed + ' days since you ran kube-hunter. You should run it again soon.';
+      this.penetrationTestStatusInvalid = true;
+      this.penetrationTestText = 'Report Outdated';
+    } else if (daysPassed >= 10) {
+      this.ourAdvice = 'It has been ' + daysPassed + ' days since you last ran kube-hunter.';
+      this.penetrationTestStatusInvalid = true;
+      this.penetrationTestText = 'Report Outdated';
+    } else {
+      this.ourAdvice = 'It has been ' + daysPassed + ' days since you last ran kube-hunter.';
+      this.penetrationTestStatusInvalid = false;
+      this.penetrationTestText = 'Report Valid';
+    }
+    recentScan.vulnerabilities?.value?.value?.forEach(vulnerability => {
+      if (vulnerability.severity === 'low') {
+        this.mostRecentVulnerabilities.low += 1;
+      } else if (vulnerability.severity === 'medium') {
+        this.mostRecentVulnerabilities.medium += 1;
+      } else if (vulnerability.severity === 'high') {
+        this.mostRecentVulnerabilities.high += 1;
+      }
+    });
+}
 
   openDialog() {
     const dialog = this.dialog.open(KubeHunterDialogComponent, {

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.ts
@@ -2,7 +2,6 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Subject} from 'rxjs';
 import {take, tap} from 'rxjs/operators';
 import {KubeHunterService} from '../../../../../core/services/kube-hunter.service';
-import {AlertService} from 'src/app/core/services/alert.service';
 import {IKubeHunterReport} from '../../../../../core/entities/IKubeHunterReport';
 import {ActivatedRoute, Router} from '@angular/router';
 import {MatTableDataSource} from '@angular/material/table';
@@ -22,6 +21,7 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
   allReportsForCluster: IKubeHunterReport[];
   scansExist = false;
   mostRecentVulnerabilities = {low: 0, medium: 0, high: 0};
+  receivedResponse = false;
 
   penetrationTestStatusInvalid: boolean;
   penetrationTestText: string;
@@ -36,7 +36,6 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
 
   constructor(
     private kubeHunterService: KubeHunterService,
-    private alertService: AlertService,
     private route: ActivatedRoute,
     private dialog: MatDialog,
     private router: Router,
@@ -63,6 +62,7 @@ export class KubeHunterComponent implements OnInit, OnDestroy {
         take(1),
       )
       .subscribe(res => {
+        this.receivedResponse = true;
         this.scansExist = !!res?.list?.length;
         this.allReportsForCluster = res?.list || [];
         this.reportCount = res?.reportCount || 0;

--- a/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.html
+++ b/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.html
@@ -1,4 +1,4 @@
-<button *ngIf="iconButton else textButton"
+<button *ngIf="iconButton || isSmallScreen else textButton"
         mat-icon-button
         (click)="copy()"
 >

--- a/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.ts
+++ b/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.ts
@@ -36,7 +36,6 @@ export class CopyToClipboardButtonComponent implements OnInit, OnDestroy {
     ) { }
 
   ngOnInit() {
-    console.log('responsicv,', this.responsive);
     if (this.responsive) {
       this.breakpointObserver.observe([Breakpoints.Handset, Breakpoints.XSmall])
         .pipe(

--- a/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.ts
+++ b/dash/frontend/src/app/modules/shared/components/copy-to-clipboard-button/copy-to-clipboard-button.component.ts
@@ -1,12 +1,17 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {Clipboard} from '@angular/cdk/clipboard';
 import {AlertService} from 'src/app/core/services/alert.service';
+import {Subject} from 'rxjs';
+import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
+import {map, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'app-copy-to-clipboard-button',
   templateUrl: './copy-to-clipboard-button.component.html',
 })
-export class CopyToClipboardButtonComponent {
+export class CopyToClipboardButtonComponent implements OnInit, OnDestroy {
+  protected readonly unsubscribe$ = new Subject<void>();
+
   /** The text that will be copied to the user's clipboard when they click the button. */
   @Input() text: string;
 
@@ -19,10 +24,29 @@ export class CopyToClipboardButtonComponent {
   /** Display only an icon as the button if true */
   @Input() iconButton = false;
 
+  /** If set to true, will turn into an icon only button on small screens. Only checked on initialization */
+  @Input() responsive = false;
+
+  isSmallScreen: boolean;
+
   constructor(
     private cb: Clipboard,
-    private readonly alertService: AlertService
+    private readonly alertService: AlertService,
+    protected readonly breakpointObserver: BreakpointObserver
     ) { }
+
+  ngOnInit() {
+    console.log('responsicv,', this.responsive);
+    if (this.responsive) {
+      this.breakpointObserver.observe([Breakpoints.Handset, Breakpoints.XSmall])
+        .pipe(
+          map(result => result.matches),
+          takeUntil(this.unsubscribe$)
+        ).subscribe({
+        next: isSmall => this.isSmallScreen = isSmall
+      });
+    }
+  }
 
   copy() {
     const success = this.cb.copy(this.text);
@@ -31,5 +55,10 @@ export class CopyToClipboardButtonComponent {
     } else {
       this.alertService.danger(this.errorMessage);
     }
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 }

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -439,7 +439,8 @@ app-private {
   width: -webkit-fill-available;
   max-height: 400px;
   resize: none;
-  margin: 0 0 16px  0;
+  margin: 0 0 16px 0;
+  box-sizing: border-box;
   // Styles below replicate StackOverflow
   background-color: #f6f6f6;
   padding: 12px;


### PR DESCRIPTION
## Kube hunter page
- Now says 'Not yet run' as pen test status, has N/A for vulnerability counts, and 'Run kube-hunter to audit your cluster security' as Our advice when no kube-hunter scan has been run for the cluster.
- Neatened up some of the kube hunter page logic
- Fixed bug where the kube hunter report pagination was based on the total number of reports for all clusters rather than just the current cluster
- Neatened spacing for copy to clipboard button

 ## Other
- Removed @types/cron package - It was causing build errors and since we don't have the main cron package is not doing anything
- Added a responsive mode to the copy to clipboard button where it will turn into an icon button rather than a text button on smaller screens.

Ticket: 6825