### PR TITLE
implement readonly checkbox component

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/api-key-management/api-key-list/api-key-list.component.html
@@ -25,11 +25,7 @@
             <ng-container matColumnDef="isActive">
               <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear>Active</th>
               <td mat-cell *matCellDef="let apikey">
-                <mat-checkbox
-                  disableRipple (click)="$event.preventDefault()"
-                  [checked]="apikey.isActive"
-                >
-                </mat-checkbox>
+                <app-readonly-checkbox [checked]="apikey.isActive"></app-readonly-checkbox>
               </td>
             </ng-container>
             <ng-container *ngIf="isAdmin" matColumnDef="edit">

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper/gate-keeper.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper/gate-keeper.component.html
@@ -95,7 +95,7 @@
                 <ng-container matColumnDef="enforced">
                   <mat-header-cell *matHeaderCellDef>Enforced</mat-header-cell>
                   <mat-cell *matCellDef="let gatekeeperTemplate">
-                    <mat-checkbox disableRipple (click)="$event.preventDefault()" [checked]="gatekeeperTemplate.enforced"></mat-checkbox>
+                    <app-readonly-checkbox [checked]="gatekeeperTemplate.enforced"></app-readonly-checkbox>
                   </mat-cell>
                 </ng-container>
                 <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-list/external-auth-configuration-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-list/external-auth-configuration-list.component.html
@@ -27,7 +27,7 @@
           <ng-container matColumnDef="isActive">
             <th mat-header-cell *matHeaderCellDef>Active</th>
             <td mat-cell *matCellDef="let authConfig">
-              <mat-checkbox disableRipple (click)="$event.preventDefault()" [checked]=authConfig?.isActive></mat-checkbox>
+              <app-readonly-checkbox [checked]="authConfig?.isActive"></app-readonly-checkbox>
             </td>
           </ng-container>
           <ng-container matColumnDef="actions">

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
@@ -156,8 +156,7 @@
             <mat-header-cell class="ps-xs-0" *matHeaderCellDef mat-sort-header="required_for_compliance" disableClear> Compliant</mat-header-cell>
             <mat-cell *matCellDef="let issue">
               <div class="row">
-                <mat-checkbox disableRipple (click)="$event.preventDefault()" [checked]="issue.isCompliant" class="pad-right-5">
-                </mat-checkbox>
+                <app-readonly-checkbox class="mr-3" [checked]="issue.isCompliant"></app-readonly-checkbox>
                 <div>
                   <mat-icon *ngIf="issue.complianceReason" [matTooltip]="issue.complianceReason">info</mat-icon>
                 </div>
@@ -209,7 +208,7 @@
           <ng-container matColumnDef="isFixable" >
             <mat-header-cell *matHeaderCellDef mat-sort-header="is_fixable" disableClear> Fixable </mat-header-cell>
             <mat-cell *matCellDef="let issue">
-              <mat-checkbox  disableRipple (click)="$event.preventDefault()"  [checked]="issue.isFixable"></mat-checkbox>
+              <app-readonly-checkbox [checked]="issue.isFixable"></app-readonly-checkbox>
               <span *ngIf="issue.isFixable"> ({{ issue.fixedVersion ? issue.fixedVersion : 'N/A' }})</span>
             </mat-cell>
           </ng-container>

--- a/dash/frontend/src/app/modules/private/pages/policies/policy-create/policy-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/policies/policy-create/policy-create.component.html
@@ -111,17 +111,13 @@
                 <ng-container matColumnDef="enabled">
                   <mat-header-cell *matHeaderCellDef>Active</mat-header-cell>
                   <mat-cell *matCellDef="let scanner">
-                    <mat-checkbox [checked]="scanner.enabled"  disableRipple
-                                  (click)="$event.preventDefault()">
-                    </mat-checkbox>
+                    <app-readonly-checkbox [checked]="scanner.enabled"></app-readonly-checkbox>
                   </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="required">
                   <mat-header-cell *matHeaderCellDef>Required</mat-header-cell>
                   <mat-cell *matCellDef="let scanner">
-                    <mat-checkbox [checked]="scanner.required" disableRipple
-                                  (click)="$event.preventDefault()">
-                    </mat-checkbox>
+                    <app-readonly-checkbox [checked]="scanner.required"></app-readonly-checkbox>
                   </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="name">

--- a/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.html
+++ b/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.html
@@ -1,0 +1,9 @@
+<mat-checkbox class="readonly-cb"
+              [disableRipple]="true"
+              (click)="$event.preventDefault()"
+              [color]="color"
+              [checked]="checked"
+              [indeterminate]="indeterminate"
+              [tabIndex]="-1"
+></mat-checkbox>
+

--- a/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.scss
+++ b/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.scss
@@ -1,0 +1,6 @@
+.readonly-cb {
+  // Combined, these 2 prevent the mouse from changing to a pointer and the
+  // 'ripple' from appearing around it when hovered over
+  cursor: unset;
+  pointer-events: none;
+}

--- a/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.ts
+++ b/dash/frontend/src/app/modules/shared/components/readonly-checkbox/readonly-checkbox.component.ts
@@ -1,0 +1,15 @@
+import {Component, Input} from '@angular/core';
+import {ThemePalette} from '@angular/material/core';
+
+
+@Component({
+  selector: 'app-readonly-checkbox',
+  templateUrl: './readonly-checkbox.component.html',
+  styleUrls: ['./readonly-checkbox.component.scss']
+})
+export class ReadonlyCheckboxComponent {
+  @Input() checked: boolean;
+  @Input() indeterminate: boolean;
+  @Input() color: ThemePalette = 'primary';
+
+}

--- a/dash/frontend/src/app/modules/shared/shared.module.ts
+++ b/dash/frontend/src/app/modules/shared/shared.module.ts
@@ -18,6 +18,8 @@ import {RouterModule, RouterOutlet} from '@angular/router';
 import {MatListModule} from '@angular/material/list';
 import { HideableTextComponent } from './components/hideable-text/hideable-text.component';
 import {USAPhoneMaskDirective} from './directives/usa-phone-mask.directive';
+import { ReadonlyCheckboxComponent } from './components/readonly-checkbox/readonly-checkbox.component';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 
 @NgModule({
   declarations: [
@@ -29,6 +31,7 @@ import {USAPhoneMaskDirective} from './directives/usa-phone-mask.directive';
     CopyToClipboardButtonComponent,
     SideNavComponent,
     HideableTextComponent,
+    ReadonlyCheckboxComponent,
   ],
   imports: [
     MatDialogModule,
@@ -43,6 +46,7 @@ import {USAPhoneMaskDirective} from './directives/usa-phone-mask.directive';
     RouterOutlet,
     RouterModule,
     MatListModule,
+    MatCheckboxModule,
   ],
   exports: [
     DatepickerComponent,
@@ -52,6 +56,7 @@ import {USAPhoneMaskDirective} from './directives/usa-phone-mask.directive';
     CopyToClipboardButtonComponent,
     SideNavComponent,
     HideableTextComponent,
+    ReadonlyCheckboxComponent,
   ]
 })
 export class SharedModule {


### PR DESCRIPTION
Created a shared readonly checkbox component and implemented in all the spots I could find that should have a readonly checkbox:
- image scan results page - compliant & fixable columns
- api key list active column
- gatekeeper template list enforced column
- auth config list enabled column
- policy add/edit scanner table required & active columns

ticket 6834