### PR TITLE
Fix Trawler scanning

### DIFF
--- a/trawler/src/main/java/io/m9sweeper/trawler/ScanRunner.java
+++ b/trawler/src/main/java/io/m9sweeper/trawler/ScanRunner.java
@@ -46,7 +46,6 @@ public class ScanRunner {
         ArrayList<ScanResult> scanResults = new ArrayList<>(0);
 
         String newImageHash = "";
-        boolean errorEncountered = false;
 
         if (policies != null && policies.size() > 0) {
             for (PolicyWithScannerDto policyWithScannerDto: policies) {
@@ -87,13 +86,11 @@ public class ScanRunner {
                             scanResultBuilder.withSummary("");
                         } catch (Exception e) {
                             scanResultBuilder.withEncounteredError(true);
-                            errorEncountered = true;
                             scanResultBuilder.withSummary(e.getMessage());
                         }
                     }
                 } else {
                     scanResultBuilder.withEncounteredError(true);
-                    errorEncountered = true;
                     scanResultBuilder.withSummary("No Scanner found");
                     if (TrawlerConfiguration.getInstance().getDebug()) System.out.println("policyWithScannerDto.getScanners().size(): " + policyWithScannerDto.getScanners().size());
                 }
@@ -168,23 +165,7 @@ public class ScanRunner {
                                 .data(o.getExtraData())
                 ).collect(Collectors.toList()))).collect(Collectors.toList());
 
-        // If we have an error, save a "blank" scan with the error, otherwise just save the actual results
-        if (errorEncountered) {
-            ImageTrawlerResultDto outdatedImageIdResult = new ImageTrawlerResultDto()
-                    .summary(imageTrawlerResultDtos.get(0).getSummary())
-                    .encounterError(true)
-                    .criticalIssues(new BigDecimal(0))
-                    .majorIssues(new BigDecimal(0))
-                    .mediumIssues(new BigDecimal(0))
-                    .lowIssues(new BigDecimal(0))
-                    .negligibleIssues(new BigDecimal(0))
-                    .policyId(imageTrawlerResultDtos.get(0).getPolicyId());
-            List<ImageTrawlerResultDto> outdatedImageIdArray = new ArrayList<ImageTrawlerResultDto>();
-            outdatedImageIdArray.add(outdatedImageIdResult);
-            saveScanResults(outdatedImageIdArray);
-        } else {
-            saveScanResults(imageTrawlerResultDtos);
-        }
+        saveScanResults(imageTrawlerResultDtos);
     }
 
     /** Throws an error if the image is not compliant  */

--- a/trawler/src/main/java/io/m9sweeper/trawler/ScanRunner.java
+++ b/trawler/src/main/java/io/m9sweeper/trawler/ScanRunner.java
@@ -176,13 +176,13 @@ public class ScanRunner {
         // Return an error response under the original hash
         if (hashHasChanged || errorEncountered) {
             String errorSummary = "";
-            if (hashHasChanged && !errorEncountered) {
+            if (errorEncountered) {
+                errorSummary = imageTrawlerResultDtos.get(0).getSummary();
+            } else {
                 errorSummary = "Image ID does not match most recent image pulled from Trawler";
                 if (scanConfig.getImage().getTag().contains("latest")) {
                     errorSummary = errorSummary.concat(". Note, using the latest tag for images is not recommended and can cause undesirable behavior");
                 }
-            } else {
-                errorSummary = imageTrawlerResultDtos.get(0).getSummary();
             }
             ImageTrawlerResultDto outdatedImageIdResult = new ImageTrawlerResultDto()
                     .summary(errorSummary)

--- a/trawler/src/main/java/io/m9sweeper/trawler/framework/docker/DockerImage.java
+++ b/trawler/src/main/java/io/m9sweeper/trawler/framework/docker/DockerImage.java
@@ -58,6 +58,38 @@ public class DockerImage {
     }
 
     /**
+     * Builds the full path that can be used in a Docker pull command
+     * @param includeRegistry Whether it should include the registry prefix
+     * @param includeHash Whether it should include the sha. Will not include the sha if it is null or starts with TMP_ regardless of the value
+     * @return the full path of the docker image
+     */
+    public String buildFullPath(boolean includeRegistry, boolean includeHash) {
+        StringBuilder builder = new StringBuilder(32);
+        if (includeRegistry) {
+            builder.append(this.registry.getHostname())
+                    .append('/');
+        }
+
+        builder.append(this.name)
+                .append(":")
+                .append(this.tag);
+
+        if (includeHash && !this.hasTempHash()) {
+            builder.append("@sha256:")
+                    .append(this.hash);
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Checks if the hash is temporary (starts with 'TMP_') or null.
+     */
+    public boolean hasTempHash() {
+        return this.hash == null || this.hash.startsWith("TMP_");
+    }
+
+    /**
      * Get the tag of the docker image
      *
      * @return the tag of the image

--- a/trawler/src/main/java/io/m9sweeper/trawler/scanners/Trivy.java
+++ b/trawler/src/main/java/io/m9sweeper/trawler/scanners/Trivy.java
@@ -63,7 +63,7 @@ public class Trivy implements Scanner {
      */
     @Override
     public void runScan() throws Exception {
-        System.out.println("Initiating scan of " + config.getImage().getName() + ":" + config.getImage().getTag() +
+        System.out.println("Initiating scan of " + config.getImage().buildFullPath(false, true) +
                 " with trivy for " + config.getPolicy().getName() + ":" + config.getScannerName());
         StringBuilder trivyScanCommandBuilder = new StringBuilder();
 
@@ -147,7 +147,7 @@ public class Trivy implements Scanner {
         // run trivy scan
         trivyScanCommandBuilder.append("trivy -q image --timeout 30m --scanners vuln -f json '");
         trivyScanCommandBuilder.append(escapeXsi(
-                registry.getHostname() + "/" + config.getImage().getName() + ":" + config.getImage().getTag()
+                config.getImage().buildFullPath(true, true)
         ));
         trivyScanCommandBuilder.append("';");
 


### PR DESCRIPTION
Changes made:
When the image digest is available, Trawler will use it to ensure the proper image is pulled. If it is not available (or is TMP_xxx) it will pull it by name and function as it previously did.


Image Id has changed... error can no longer happen, as Trawler will now pull the old version.

For exampl: If we have an nginx:latest running in our cluster that is actually nginx:1.20, when scanned, it will pull using the digest, so it will actually scan nginx:1.20 and give the expected result for that scan. With the old behavior, Trawler would pull nginx:latest by name, but would actually get nginx:1.25, and this would result in the Image ID does not match.... error, and no possibility of scanning that older nginx:latest image.