### PR TITLE
Fix cluster sync tagless images

### DIFF
--- a/dash/backend/src/modules/k8s-image/services/k8s-image.service.ts
+++ b/dash/backend/src/modules/k8s-image/services/k8s-image.service.ts
@@ -226,14 +226,25 @@ export class K8sImageService {
      * Prefix with default image registry if required
      * @param image
      */
-    formatDockerImageUrl(image: string) {
-        const k8Image = image.split('/');
-        if (k8Image.length > 0) {
-            const url = k8Image[0];
-            const urlMatch = url.match(/^([a-z0-9|-]+\.)*[a-z0-9|-]+\.[a-z]+/i);
-            return urlMatch === null ? this.DEFAULT_DOCKER_REGISTRY + '/' + image : image;
+    formatDockerImageUrl(image: string): string {
+        const splitOnColon = image.split(':');
+        let imageTag = '';
+        if (splitOnColon.length > 1) {
+            imageTag = splitOnColon[splitOnColon.length - 1];
         }
-        return this.DEFAULT_DOCKER_REGISTRY + '/' + image;
+        if (!imageTag) { imageTag = 'latest'; }
+        const splitOnSlash = splitOnColon[0].split('/');
+        let containerRegistry = this.DEFAULT_DOCKER_REGISTRY;
+        if (splitOnSlash[0].split('.').length > 1) {
+            containerRegistry = splitOnSlash.shift();
+        }
+        let containerPath = '';
+        while (splitOnSlash.length > 1) {
+            containerPath += `${splitOnSlash.shift()}/`;
+        }
+        containerPath += splitOnSlash.shift();
+
+        return `${containerRegistry}/${containerPath}:${imageTag}`
     }
 
     async enqueueScan(imageHash: string, clusterId: number): Promise<void> {


### PR DESCRIPTION
Now in the function that builds the image url to match what the equivalent function used in the frontends add image button.


Will auto prefix with default docker registry if no docker registry in image name
Will assume the tag is latest if none is provided

Ex. 
nginx -> docker.io/nginx:latest
registry.k8s.io/kube-proxy:v1.27.2 -> registry.k8s.io/kube-proxy:v1.27.2 [same] 