### PR TITLE
Fix GHCR login and m9sweeper installation when waits failed

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -34,8 +34,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.M9SWEEPER_PACKAGES_USERNAME }}
-          password: ${{ secrets.M9SWEEPER_PACKAGES_PAT }}
+          username: m9sweeper
+          password: ${{ github.token }}
 
       - name: Build & Push Dash (amd64)
         uses: docker/build-push-action@v4
@@ -79,8 +79,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.M9SWEEPER_PACKAGES_USERNAME }}
-          password: ${{ secrets.M9SWEEPER_PACKAGES_PAT }}
+          username: m9sweeper
+          password: ${{ github.token }}
 
       - name: Build & Push Trawler (amd64)
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -34,8 +34,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.M9SWEEPER_PACKAGES_USERNAME }}
+          password: ${{ secrets.M9SWEEPER_PACKAGES_PAT }}
 
       - name: Build & Push Dash (amd64)
         uses: docker/build-push-action@v4
@@ -79,8 +79,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.M9SWEEPER_PACKAGES_USERNAME }}
+          password: ${{ secrets.M9SWEEPER_PACKAGES_PAT }}
 
       - name: Build & Push Trawler (amd64)
         uses: docker/build-push-action@v4

--- a/.github/workflows/selenium-test.yaml
+++ b/.github/workflows/selenium-test.yaml
@@ -74,7 +74,7 @@ jobs:
           checkName: 'Build Docker Images / Build Trawler Image'
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeoutSeconds: 1800
+          timeoutSeconds: 3600
 
       - name: Wait for Dash Build
         uses: fountainhead/action-wait-for-check@v1.1.0
@@ -83,9 +83,11 @@ jobs:
           checkName: 'Build Docker Images / Build Dash Image'
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeoutSeconds: 1800
+          timeoutSeconds: 3600
 
       - name: Install m9sweeper
+        if: steps.dash_build_wait.outputs.conclusion == 'success' && steps.trawler_build_wait.outputs.conclusion == 'success'
+        id: install_m9sweeper
         run: |
           helm_upgrade_cmd="helm upgrade m9sweeper m9sweeper/m9sweeper --install --wait --create-namespace --namespace m9sweeper-system \
             --set-string dash.init.superAdminEmail=\"super.admin@intelletive.com\" \
@@ -117,7 +119,7 @@ jobs:
       - name: Run Selenium Tests
         continue-on-error: true
         working-directory: selenium-testing/
-        if: success()
+        if: success() && steps.install_m9sweeper.outcome != 'skipped'
         run: |
           export GATEKEEPER_VERSION=${{ inputs.gatekeeper-version }}
           export DOCKER_REGISTRY="public-docker.nexus.celestialdata.net"
@@ -128,7 +130,7 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
-        if: success() || failure()
+        if: (success() || failure()) && steps.install_m9sweeper.outcome != 'skipped'
         with:
           path: |
             selenium-testing/screenshots/


### PR DESCRIPTION
Changes the GHCR login steps to use a PAT so that packages can be pushed when running PR checks from a forked repository. Also fixes an issue where the Install m9sweeper step under the selenium tests still happens even if the wait steps for the dash/trawler images produced a failure outcome.