### PR TITLE
Add workflows for PR's that are from forks

### DIFF
--- a/.github/workflows/forked-pr.yaml
+++ b/.github/workflows/forked-pr.yaml
@@ -1,0 +1,170 @@
+name: Forked PR Testing
+
+on:
+  workflow_call:
+    inputs:
+      kubernetes-version:
+        required: false
+        type: string
+        default: 'v1.27.3'
+      gatekeeper-version:
+        required: false
+        type: string
+        default: '3.12.0'
+      helm-version:
+        required: false
+        type: string
+        default: '3.12.0'
+      dash-image-version:
+        required: false
+        type: string
+      dash-image-tags:
+        required: true
+        type: string
+      trawler-image-version:
+        required: false
+        type: string
+      trawler-image-tags:
+        required: true
+        type: string
+      m9sweeper-chart-version:
+        required: false
+        type: string
+      cni:
+        required: false
+        type: string
+        default: 'calico'
+
+jobs:
+  run_tests:
+    name: Test on k8s ${{ inputs.kubernetes-version }}
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ inputs.helm-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: ${{ inputs.kubernetes-version }}
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'selenium-testing/.nvmrc'
+
+      - name: Install Google Chrome
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt install -y ./google-chrome-stable_current_amd64.deb
+          rm google-chrome-stable_current_amd64.deb
+
+      - name: Add m9sweeper helm repository
+        run: |
+          helm repo add m9sweeper https://m9sweeper.github.io/m9sweeper
+          helm repo update
+
+      - name: Build Dash
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          provenance: false
+          tags: ${{ inputs.dash-image-tags }}
+          cache-from: type=gha,scope=build-dash-amd64
+          cache-to: type=gha,mode=max,scope=build-dash-amd64
+
+      - name: Build Trawler
+        uses: docker/build-push-action@v4
+        with:
+          context: trawler/
+          push: false
+          provenance: false
+          tags: ${{ inputs.trawler-image-tags }}
+          cache-from: type=gha,scope=build-trawler-amd64
+          cache-to: type=gha,mode=max,scope=build-trawler-amd64
+
+      - name: Start minikube
+        run: minikube start --cpus=4 --memory=6g --cni=${{ inputs.cni }} --kubernetes-version=${{ inputs.kubernetes-version }}
+
+      - name: Load images to minikube
+        run: |
+          minikube image load ghcr.io/m9sweeper/dash:${{ inputs.dash-image-version }}
+          minikube image load ghcr.io/m9sweeper/trawler:${{ inputs.trawler-image-version }}
+
+      - name: Install m9sweeper
+        run: |
+          helm_upgrade_cmd="helm upgrade m9sweeper m9sweeper/m9sweeper --install --wait --create-namespace --namespace m9sweeper-system \
+            --set-string dash.init.superAdminEmail=\"super.admin@intelletive.com\" \
+            --set-string dash.init.superAdminPassword=\"123456\" \
+            --set-string global.apiKey=\"myapikey123456\" \
+            --set-string global.jwtSecret=testsecret \
+            --set-string rabbitmq.image.repository=\"ghcr.io/m9sweeper/rabbitmq\" \
+            --set-string postgresql.image.repository=\"ghcr.io/m9sweeper/postgres\" \
+            --set-string postgresql.volumePermissions.image.repository=\"ghcr.io/m9sweeper/debian\" \
+            --set-string dash.kubesec.registry=\"ghcr.io\" \
+            --set-string dash.kubesec.repository=\"m9sweeper/kubesec\" \
+            --set-string dash.image.pullPolicy=\"Never\" \
+            --set-string dash.image.tag=\"${{ inputs.dash-image-version }}\" \
+            --set-string trawler.image.pullPolicy=\"Never\" \
+            --set-string trawler.image.tag=\"${{ inputs.trawler-image-version }}\" \
+            --debug --timeout 10m0s"
+
+          if [ -n "${{ inputs.m9sweeper-chart-version }}" ]; then
+            helm_upgrade_cmd="${helm_upgrade_cmd} --version ${{ inputs.m9sweeper-chart-version }}"
+          fi
+
+          echo "$helm_upgrade_cmd"
+          eval "$helm_upgrade_cmd"
+
+      - name: Run Selenium Tests
+        continue-on-error: true
+        working-directory: selenium-testing/
+        if: success()
+        run: |
+          export GATEKEEPER_VERSION=${{ inputs.gatekeeper-version }}
+          export DOCKER_REGISTRY="public-docker.nexus.celestialdata.net"
+          export SKIP_GATEKEEPER_TESTS="false"
+          kubectl port-forward service/m9sweeper-dash 3000:3000 -n m9sweeper-system > /dev/null &
+          npm install -y
+          npm run test:pipeline
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          path: |
+            selenium-testing/screenshots/
+            selenium-testing/downloads/
+            selenium-testing/reports/
+          if-no-files-found: ignore
+          name: k8s-${{ inputs.kubernetes-version }}-testing-artifacts
+
+      - name: Upload Test Reports
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure()
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        with:
+          report_paths: selenium-testing/reports/*.xml
+          fail_on_failure: true
+          require_passed_tests: true
+          detailed_summary: true
+          include_passed: true
+          check_name: Test Report - k8s ${{ inputs.kubernetes-version }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          minikube delete
+          helm repo remove m9sweeper

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,10 @@ on:
       - 'trawler/**'
       - 'Dockerfile'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   versioning:
     name: Determine Image Versioning
@@ -55,6 +59,7 @@ jobs:
     name: Build Docker Images
     uses: ./.github/workflows/docker-build.yaml
     needs: versioning
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true)
     permissions:
       packages: write
     with:
@@ -65,6 +70,7 @@ jobs:
     name: Run Selenium Tests
     uses: ./.github/workflows/selenium-test.yaml
     needs: versioning
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true)
     permissions:
       checks: write
     with:
@@ -73,3 +79,19 @@ jobs:
       helm-version: 'v3.12.0'
       dash-image-version: ${{ needs.versioning.outputs.dash-image-version }}
       trawler-image-version: ${{ needs.versioning.outputs.trawler-image-version }}
+
+  forked_pr_tests:
+    name: Run Selenium Tests
+    uses: ./.github/workflows/forked-pr.yaml
+    needs: versioning
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    permissions:
+      checks: write
+    with:
+      kubernetes-version: 'v1.27.3'
+      gatekeeper-version: '3.12.0'
+      helm-version: 'v3.12.0'
+      dash-image-version: ${{ needs.versioning.outputs.dash-image-version }}
+      dash-image-tags: ${{ needs.versioning.outputs.dash-image-tags }}
+      trawler-image-version: ${{ needs.versioning.outputs.trawler-image-version }}
+      trawler-image-tags: ${{ needs.versioning.outputs.trawler-image-tags }}


### PR DESCRIPTION
Since secrets are not shared to workflows triggered by forks, a new workflow is created to run everything without the need to push to the docker registry and thus not need the secrets.