### PR TITLE
Ensure dash imagePullPolicy is respected

### DIFF
--- a/manifests/charts/dash/templates/cronjob-exception-status-update.yaml
+++ b/manifests/charts/dash/templates/cronjob-exception-status-update.yaml
@@ -34,6 +34,7 @@ spec:
           containers:
             - name: {{ include "dash.fullname" . }}-scrape-history
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["npm"]
               args:
                 - "run"

--- a/manifests/charts/dash/templates/cronjob-gatekeeper-exception-block.yaml
+++ b/manifests/charts/dash/templates/cronjob-gatekeeper-exception-block.yaml
@@ -34,6 +34,7 @@ spec:
           containers:
             - name: {{ include "dash.fullname" . }}-scrape-history
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["npm"]
               args:
                 - "run"

--- a/manifests/charts/dash/templates/cronjob-scrape-history.yaml
+++ b/manifests/charts/dash/templates/cronjob-scrape-history.yaml
@@ -34,6 +34,7 @@ spec:
           containers:
             - name: {{ include "dash.fullname" . }}-scrape-history
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["npm"]
               args:
                 - "run"

--- a/manifests/charts/dash/templates/cronjob-scrape.yaml
+++ b/manifests/charts/dash/templates/cronjob-scrape.yaml
@@ -34,6 +34,7 @@ spec:
           containers:
             - name: {{ .Chart.Name }}-scheduled-scrape
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["npm"]
               args:
                 - "run"

--- a/manifests/charts/dash/templates/dash-falco.yaml
+++ b/manifests/charts/dash/templates/dash-falco.yaml
@@ -77,6 +77,7 @@ spec:
 {{- toYaml .Values.resources | nindent 12 }}
         - name: kubesec
           image: "{{ .Values.kubesec.registry }}/{{ .Values.kubesec.repository }}:{{ .Values.kubesec.tag }}"
+          imagePullPolicy: {{ .Values.kubesec.pullPolicy }}
           ports:
             - containerPort: 8080
           resources:

--- a/manifests/charts/dash/templates/deployment.yaml
+++ b/manifests/charts/dash/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
         - name: wait-for-postgresql
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - 'sh'
             - '-c'
@@ -82,6 +82,7 @@ spec:
 {{- toYaml .Values.resources | nindent 12 }}
         - name: kubesec
           image: "{{ .Values.kubesec.registry }}/{{ .Values.kubesec.repository }}:{{ .Values.kubesec.tag }}"
+          imagePullPolicy: {{ .Values.kubesec.pullPolicy }}
           ports:
             - containerPort: 8080
           resources:

--- a/manifests/charts/dash/templates/job-init.yaml
+++ b/manifests/charts/dash/templates/job-init.yaml
@@ -14,7 +14,7 @@ spec:
       initContainers:
         - name: wait-for-postgresql
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - 'sh'
             - '-c'
@@ -28,6 +28,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}-init
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["npm"]
         args:
           - "run"


### PR DESCRIPTION
Update the dash chart to ensure that the pullPolicy for the dash and kubesec images is actually respected and used. This is needed when installing in minikube and images have been manually loaded via the `minikube image load` command since you need to set the imagePullPolicy to `Never` in that situation.