### PR TITLE
Fixes for: falco sort, logs "floating" cluster compliance graph 

### DIFF
--- a/dash/backend/src/modules/cluster-group/dao/cluster-group-dao.ts
+++ b/dash/backend/src/modules/cluster-group/dao/cluster-group-dao.ts
@@ -14,12 +14,18 @@ export class ClusterGroupDao {
             .select([
                 'cg.id as _id',
                 'cg.name as _name',
-                'cg.user_id as _userId' ])
+                'cg.user_id as _userId',
+                'cg.created_at as _createdAt'
+            ])
             .from('cluster_group as cg')
             .where('cg.id', id)
             .andWhere('cg.deleted_at', null)
         )
-            .then(clusterGroup => plainToInstance(ClusterGroupDto, clusterGroup?.[0]));
+            .then(clusterGroup => {
+                const instance = plainToInstance(ClusterGroupDto, clusterGroup?.[0]);
+                instance.createdAt = +instance.createdAt;
+                return instance
+            });
     }
 
     async getClusterGroups(): Promise<ClusterGroupDto[]> {

--- a/dash/backend/src/modules/cluster/dao/cluster.dao.ts
+++ b/dash/backend/src/modules/cluster/dao/cluster.dao.ts
@@ -72,7 +72,7 @@ export class ClusterDao {
         const knex = await this.databaseService.getConnection();
         return knexnest(knex
             .select(['c.id as _id', 'c.name as _name', 'c.ip_address as _ipAddress', 'c.port as _port',
-                'c.context as _context', 'c.tags as _tags', 'c.group_id as _groupId',
+                'c.context as _context', 'c.tags as _tags', 'c.group_id as _groupId', 'c.created_at as _createdAt',
                 'c.is_enforcement_enabled as _isEnforcementEnabled', 'c.kube_config as _kubeConfig',
                 'c.is_image_scanning_enforcement_enabled as _isImageScanningEnforcementEnabled',
                 'c.grace_period_days as _gracePeriodDays'])
@@ -80,7 +80,11 @@ export class ClusterDao {
             .where('c.id', id)
             .andWhere('c.deleted_at', null)
             .orderBy('id', 'desc'))
-            .then(result => plainToInstance(ClusterDto, result[0]));
+            .then(result => {
+              const instance = plainToInstance(ClusterDto, result[0]);
+              instance.createdAt = + instance.createdAt;
+              return instance;
+            });
     }
 
     async getClustersByGroupId(id: number): Promise<ClusterDto[]> {

--- a/dash/backend/src/modules/falco/dao/falco.dao.ts
+++ b/dash/backend/src/modules/falco/dao/falco.dao.ts
@@ -8,8 +8,7 @@ import {FalcoSettingDto} from "../dto/falco-setting.dto";
 import * as knexnest from 'knexnest'
 import {FalcoEmailDto} from "../dto/falco-email.dto";
 import { FalcoRuleCreateDto, FalcoRuleDto } from '../dto/falco-rule.dto';
-import { knex, Knex } from 'knex';
-import QueryBuilder = knex.QueryBuilder;
+import { Knex } from 'knex';
 
 
 @Injectable()
@@ -31,53 +30,42 @@ export class FalcoDao {
         if (priorities) {
             query = query.whereIn('level', priorities);
         }
-        const relevantOrderBys = [
-          'Priority Desc',
-          'Priority Asc',
-          'Date Desc',
-          'Date Asc',
-          null,
-          undefined,
-        ];
-        if (orderBy in relevantOrderBys) {
-            switch (orderBy) {
-                case 'Priority Desc':
-                    query = query.orderByRaw(
-                      'CASE ' +
-                      ' WHEN level = \'Emergency\' then 1' +
-                      ' WHEN level = \'Alert\' then 2' +
-                      ' WHEN level = \'Critical\' then 3' +
-                      ' WHEN level = \'Error\' then 4' +
-                      ' WHEN level = \'Warning\' then 5' +
-                      ' WHEN level = \'Notice\' then 6' +
-                      ' WHEN level = \'Informational\' then 7' +
-                      ' WHEN level = \'Debug\' then 8' +
-                      'END'
-                    );
-                    break;
-                case 'Priority Asc':
-                    query = query.orderByRaw(
-                      'CASE ' +
-                      ' WHEN level = \'Debug\' then 1' +
-                      ' WHEN level = \'Informational\' then 2' +
-                      ' WHEN level = \'Notice\' then 3' +
-                      ' WHEN level = \'Warning\' then 4' +
-                      ' WHEN level = \'Error\' then 5' +
-                      ' WHEN level = \'Critical\' then 6' +
-                      ' WHEN level = \'Alert\' then 7' +
-                      ' WHEN level = \'Emergency\' then 8' +
-                      'END'
-                    );
-                    break;
-                case 'Date Desc':
-                    query = query.orderBy([{column: 'creation_timestamp', order: 'desc'}]);
-                    break;
-                case 'Date Asc':
-                    query = query.orderBy([{column: 'creation_timestamp', order: 'asc'}]);
-                    break;
-                default:
-                    query = query.orderBy([{column: 'id', order: 'desc'}]);
-            }
+        switch (orderBy) {
+            case 'Priority Desc':
+                query = query.orderByRaw(
+                  'CASE ' +
+                  ' WHEN level = \'Emergency\' then 1' +
+                  ' WHEN level = \'Alert\' then 2' +
+                  ' WHEN level = \'Critical\' then 3' +
+                  ' WHEN level = \'Error\' then 4' +
+                  ' WHEN level = \'Warning\' then 5' +
+                  ' WHEN level = \'Notice\' then 6' +
+                  ' WHEN level = \'Informational\' then 7' +
+                  ' WHEN level = \'Debug\' then 8' +
+                  'END'
+                );
+                break;
+            case 'Priority Asc':
+                query = query.orderByRaw(
+                  'CASE ' +
+                  ' WHEN level = \'Debug\' then 1' +
+                  ' WHEN level = \'Informational\' then 2' +
+                  ' WHEN level = \'Notice\' then 3' +
+                  ' WHEN level = \'Warning\' then 4' +
+                  ' WHEN level = \'Error\' then 5' +
+                  ' WHEN level = \'Critical\' then 6' +
+                  ' WHEN level = \'Alert\' then 7' +
+                  ' WHEN level = \'Emergency\' then 8' +
+                  'END'
+                );
+                break;
+            case 'Date Asc':
+                query = query.orderBy([{column: 'creation_timestamp', order: 'asc'}]);
+                break;
+            case 'Date Desc':
+            default:
+                query = query.orderBy([{column: 'creation_timestamp', order: 'desc'}]);
+                break;
         }
 
         if (startDate) {

--- a/dash/backend/src/modules/pod/controllers/pod.controller.ts
+++ b/dash/backend/src/modules/pod/controllers/pod.controller.ts
@@ -1,4 +1,14 @@
-import {BadRequestException, Controller, Get, Inject, Param, Query, UseGuards, UseInterceptors} from '@nestjs/common';
+import {
+    BadRequestException,
+    Controller,
+    Get,
+    HttpException, HttpStatus,
+    Inject,
+    Param,
+    Query,
+    UseGuards,
+    UseInterceptors
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ResponseTransformerInterceptor } from '../../../interceptors/response-transformer.interceptor';
 import { PodDto } from '../dto/pod-dto';
@@ -11,6 +21,7 @@ import {AuthGuard} from "../../../guards/auth.guard";
 import {AuthorityGuard} from "../../../guards/authority.guard";
 import { PodComplianceSummaryDto } from '../dto/pod-compliance-summary-dto';
 import { GatekeeperService } from '../../gatekeeper/services/gatekeeper.service';
+import {ClusterService} from '../../cluster/services/cluster.service';
 
 @ApiTags('Pods')
 @Controller()
@@ -21,6 +32,7 @@ export class PodController {
       @Inject('LOGGED_IN_USER') private readonly _loggedInUser: UserProfileDto,
       private readonly podService: PodService,
       private readonly gatekeeperService: GatekeeperService,
+      protected readonly clusterService: ClusterService,
     ) {}
 
     @Get()
@@ -137,7 +149,15 @@ export class PodController {
     })
     async getPodsComplianceSummary(
       @Query('clusterId') clusterId: number): Promise<PodComplianceSummaryDto[]> {
-        return await this.podService.getPodsComplianceSummary(clusterId);
+        let clusterCreationDate: Date = undefined;
+        if (clusterId) {
+            const cluster = await this.clusterService.getClusterById(clusterId);
+            if (!cluster) {
+                throw new HttpException('Cluster not found', HttpStatus.NOT_FOUND);
+            }
+            clusterCreationDate = new Date(cluster.createdAt);
+        }
+        return await this.podService.getPodsComplianceSummary(clusterId, clusterCreationDate);
     }
 
     @Get(':podIdentifier')

--- a/dash/backend/src/modules/pod/services/pod.service.ts
+++ b/dash/backend/src/modules/pod/services/pod.service.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { PodDao } from '../dao/pod.dao';
 import { PodDto } from '../dto/pod-dto';
 import { V1Pod } from '@kubernetes/client-node/dist/gen/model/v1Pod';
-import { lastThirtyDaysFromYesterDayAsStr, previousDayDate, yesterdaysDate } from '../../../util/date_util';
+import {
+    getDaysBetween,
+    previousDayDate,
+    yesterdaysDate
+} from '../../../util/date_util';
 import { PodComplianceSummaryDto } from '../dto/pod-compliance-summary-dto';
 import { PodComplianceSummaryGroupDto } from '../dto/pod_compliance_sumamry_group_dto';
 import { format } from 'date-fns';
@@ -149,32 +153,27 @@ export class PodService {
         return await this.podDao.getCurrentPodsComplianceSummary(clusterId);
     }
 
-    async getPodsComplianceSummary(clusterId: number): Promise<PodComplianceSummaryDto[]> {
-        let yesterDayDate = yesterdaysDate();
-        let dateBack30Days = previousDayDate(28);
+    async getPodsComplianceSummary(clusterId: number, clusterCreationDate?: Date): Promise<PodComplianceSummaryDto[]> {
+        const yesterDayDate = yesterdaysDate();
+        const defaultStart = previousDayDate(28);
+        // If the cluster creation date is after the default start date, use it sa the start date
+        const startDate = clusterCreationDate && clusterCreationDate > defaultStart ? clusterCreationDate : defaultStart;
 
-        let historyPodsOf30Days: PodComplianceSummaryGroupDto[];
+        const historyPodsOf30Days: PodComplianceSummaryGroupDto[]
+          = await this.podDao.getPodsComplianceSummaryBetweenDates(clusterId,
+          format(startDate, 'yyyy-MM-dd'), format(yesterDayDate, 'yyyy-MM-dd'));
 
-        if (clusterId) {
-            historyPodsOf30Days = await this.podDao.getPodsComplianceSummaryBetweenDates(clusterId,
-                format(dateBack30Days, 'yyyy-MM-dd'), format(yesterDayDate, 'yyyy-MM-dd'));
-        }
-        else {
-            historyPodsOf30Days = await this.podDao.getPodsComplianceSummaryBetweenDates(undefined,
-                format(dateBack30Days, 'yyyy-MM-dd'), format(yesterDayDate, 'yyyy-MM-dd'));
-        }
-
-        let podsSummaries: PodComplianceSummaryDto[] = [];
+        const podsSummaries: PodComplianceSummaryDto[] = [];
 
         if (historyPodsOf30Days) {
-            let last30Days = lastThirtyDaysFromYesterDayAsStr(28);
+            const days = getDaysBetween(startDate, yesterDayDate);
 
-            for (let dayStr of last30Days) {
-                let summaryDto = new PodComplianceSummaryDto();
+            for (const dayStr of days) {
+                const summaryDto = new PodComplianceSummaryDto();
                 summaryDto.dateString = dayStr;
                 summaryDto.percentage = 0;
 
-                let historyPods = historyPodsOf30Days.filter(p => format(p.savedDate, 'yyyy-M-d') === dayStr);
+                const historyPods = historyPodsOf30Days.filter(p => format(p.savedDate, 'yyyy-M-d') === dayStr);
 
                 if (!!historyPods === false) {
                     podsSummaries.push(summaryDto);
@@ -182,19 +181,15 @@ export class PodService {
                     continue;
                 }
 
-                let total = historyPods.reduce((sum, element) => {
+                const total = historyPods.reduce((sum, element) => {
                     return sum + (+element.count);
                 }, 0);
 
-                let compliantPodsCount = historyPods.filter(p => p.compliant).reduce((sum, element) => {
+                const compliantPodsCount = historyPods.filter(p => p.compliant).reduce((sum, element) => {
                     return sum + (+element.count);
                 }, 0);
 
-                let percentage = 0;
-
-                if (total > 0) {
-                    percentage = (compliantPodsCount * 100) / total;
-                }
+                const percentage = total > 0 ? (compliantPodsCount * 100) / total : 100;
 
                 summaryDto.dateString = dayStr;
                 summaryDto.percentage = percentage;

--- a/dash/backend/src/modules/pod/services/pod.service.ts
+++ b/dash/backend/src/modules/pod/services/pod.service.ts
@@ -153,15 +153,15 @@ export class PodService {
         return await this.podDao.getCurrentPodsComplianceSummary(clusterId);
     }
 
-    async getPodsComplianceSummary(clusterId: number, clusterCreationDate?: Date): Promise<PodComplianceSummaryDto[]> {
+    async getPodsComplianceSummary(options?: {clusterId?: number, clusterGroupId?: number, earliestStartDate?: Date}): Promise<PodComplianceSummaryDto[]> {
         const yesterDayDate = yesterdaysDate();
         const defaultStart = previousDayDate(28);
         // If the cluster creation date is after the default start date, use it sa the start date
-        const startDate = clusterCreationDate && clusterCreationDate > defaultStart ? clusterCreationDate : defaultStart;
+        const startDate = options?.earliestStartDate && options.earliestStartDate > defaultStart ? options.earliestStartDate : defaultStart;
 
         const historyPodsOf30Days: PodComplianceSummaryGroupDto[]
-          = await this.podDao.getPodsComplianceSummaryBetweenDates(clusterId,
-          format(startDate, 'yyyy-MM-dd'), format(yesterDayDate, 'yyyy-MM-dd'));
+          = await this.podDao.getPodsComplianceSummaryBetweenDates(format(startDate, 'yyyy-MM-dd'),
+          format(yesterDayDate, 'yyyy-MM-dd'), { clusterId: options?.clusterId, clusterGroupId: options?.clusterGroupId });
 
         const podsSummaries: PodComplianceSummaryDto[] = [];
 

--- a/dash/backend/src/util/date_util.ts
+++ b/dash/backend/src/util/date_util.ts
@@ -45,3 +45,19 @@ export const lastThirtyDaysFromYesterDayAsStr = function lastThirtyDaysFromYeste
   
   return dayStrings;
 }
+
+/** Returns all the days between the given dates in yyyy-M-d format */
+export const getDaysBetween = function(start: Date, end: Date): string[] {
+  // Ensure start & end are both valid dates
+  if (isNaN(start?.getTime()) || isNaN(end?.getTime())) {
+    return [];
+  }
+  const days = [];
+  const current = new Date(start.getTime()); // copy so that we don't mutate the original
+  while(current < end) {
+    days.push(format(current, 'yyyy-M-d'));
+    current.setDate(current.getDate() + 1); // mutates current
+  }
+  return days;
+}
+

--- a/dash/frontend/src/app/core/services/pod.service.ts
+++ b/dash/frontend/src/app/core/services/pod.service.ts
@@ -89,7 +89,15 @@ export class PodService {
     );
   }
 
-  getPodsComplianceSummary(clusterId: number): Observable<IServerResponse<IPodComplianceSummary[]>> {
-    return this.httpClient.get(`/api/k8s-pods/summary`,{params: new HttpParams().set('clusterId', String(clusterId))});
+  getPodsComplianceSummary(options?: {clusterId?: number, clusterGroupId?: number}): Observable<IServerResponse<IPodComplianceSummary[]>> {
+    let params = new HttpParams();
+    if (options?.clusterId) {
+      params = params.set('clusterId', String(options.clusterId));
+    }
+    if (options?.clusterGroupId) {
+      params = params.set('clusterGroupId', String(options.clusterGroupId));
+    }
+
+    return this.httpClient.get(`/api/k8s-pods/summary`, { params });
   }
 }

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-list/cluster-list.component.ts
@@ -347,7 +347,7 @@ export class ClusterListComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   getPodComplianceSummaryForAllClusters() {
-    this.podService.getPodsComplianceSummary(undefined)
+    this.podService.getPodsComplianceSummary({ clusterGroupId: this.groupId})
       .pipe(take(1))
       .subscribe(response => {
       const complianceSummaryData = response.data;

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.html
@@ -229,6 +229,9 @@
               </tr>
               </tbody>
             </table>
+            <ngx-ui-loader [loaderId]="logLoaderName" [bgsType]="logsLoaderConfig.bgsType"
+                           [bgsPosition]="logsLoaderConfig.bgsPosition">
+            </ngx-ui-loader>
           </div>
         </mat-card>
       </div>

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.scss
@@ -71,9 +71,9 @@ mat-card-title {
   }
 
   #cluster-event-items {
-    max-height: 8em;  // smaller than the #cluster-events element to account for margins & header
+    height: 8em;  // smaller than the #cluster-events element to account for margins & header
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
     flex: none;
 
     table {

--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-summary/cluster-summary.component.ts
@@ -185,7 +185,7 @@ export class ClusterSummaryComponent implements OnInit, AfterViewInit, OnDestroy
   }
 
   getPodComplianceSummaryForAllClusters(clusterId: number) {
-    this.podService.getPodsComplianceSummary(clusterId)
+    this.podService.getPodsComplianceSummary({ clusterId })
         .pipe(take(1))
         .subscribe(response => {
       const complianceSummaryData = response.data;

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.ts
@@ -55,7 +55,7 @@ export class FalcoEventsListComponent implements OnInit {
   ngOnInit() {
     this.filterForm = this.formBuilder.group({
       selectedPriorityLevels: [[]],
-      selectedOrderBy: [],
+      selectedOrderBy: ['Date Desc'],
       startDate: [],
       endDate: [],
       namespaceInput: [],


### PR DESCRIPTION
## Falco Logs (Ticket 6881)
The switch for which sort to use was wrapped in an if statement requiring specific sorts. Since there is no default sort, this was effectively preventing it from reaching the default sort case.

Changed it so it always uses the switch statement, and now defaults to date instead of id for default sort.
Also made UI start with date descending selected as the default sort to make this explicit

## Floating Cluster Logs (Ticket 6842)
Changed it from a max-height to a height for its container, so it is now sticky and always takes up the same amount of space on the bottom of the screen.

Also added a loader to the logs to make the infinite scroll more obvious.

## Cluster Compliance Graph (Ticket 6824)
2 changes made to solve for dates with no scans looking unscanned:
1. The graph now only includes dates where the cluster/cluster group existed.
     a. Effectively this means instead of always starting 28 days ago, it now starts 28 days ago, or when the cluster [group] was created - whichever was more recent
2. If there was no data for a day now defaults to 100% compliance instead of 0% compliance

### Other compliance graph bug
The cluster compliance graph on the cluster group page actually shows compliance over EVERY cluster and cluster group, rather than just its group. Added functionality so the compliance endpoint can work by cluster or cluster group.



