### PR TITLE
Determine Authority Levels based on AD groups (Ticket 6743)

### DIFF
--- a/dash/backend/src/modules/auth/dto/external-auth-config-dto.ts
+++ b/dash/backend/src/modules/auth/dto/external-auth-config-dto.ts
@@ -1,5 +1,6 @@
 import { Expose, Type} from 'class-transformer';
 import {
+    IsArray,
     IsBoolean,
     IsEnum,
     IsLowercase,
@@ -45,7 +46,24 @@ export class AzureOAuth2AuthStrategyConfigDTO extends AuthStrategyConfigDTO {
     @IsOptional()
     @IsNumber()
     defaultAuthorityId: AuthorityId;
+
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => AzureOAuth2AuthStrategyConfigDTOGroupAuthority)
+    groupAuthorities: AzureOAuth2AuthStrategyConfigDTOGroupAuthority[];
 }
+
+export class AzureOAuth2AuthStrategyConfigDTOGroupAuthority {
+    @IsString()
+    @IsNotEmpty()
+    groupId: string;
+
+    @IsNumber()
+    @IsNotEmpty()
+    authorityId: number;
+}
+
 
 export class OAuth2AuthStrategyConfigDTO extends AuthStrategyConfigDTO {
 

--- a/dash/backend/src/modules/auth/dto/external-auth-config-dto.ts
+++ b/dash/backend/src/modules/auth/dto/external-auth-config-dto.ts
@@ -13,6 +13,7 @@ import {
 import { AuthenticationType } from '../enum/AuthenticationType';
 import {ApiProperty} from '@nestjs/swagger';
 import {ProviderType} from "../enum/ProviderType";
+import {AuthorityId} from '../../user/enum/authority-id';
 
 export abstract class AuthStrategyConfigDTO {
 }
@@ -40,6 +41,10 @@ export class AzureOAuth2AuthStrategyConfigDTO extends AuthStrategyConfigDTO {
     @IsString({each: true})
     @IsLowercase({each: true})
     allowedDomains: string[];
+
+    @IsOptional()
+    @IsNumber()
+    defaultAuthorityId: AuthorityId;
 }
 
 export class OAuth2AuthStrategyConfigDTO extends AuthStrategyConfigDTO {

--- a/dash/backend/src/modules/auth/models/auth-configuration.ts
+++ b/dash/backend/src/modules/auth/models/auth-configuration.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
 import { AuthenticationType } from '../enum/AuthenticationType';
 import {ProviderType} from "../enum/ProviderType";
+import {AuthorityId} from '../../user/enum/authority-id';
 
 export class AuthStrategyConfig {
 
@@ -14,6 +15,24 @@ export class OAuth2AuthStrategyConfig extends AuthStrategyConfig{
   redirectUri:      string;
   scopes:           string[];
   allowedDomains:   string[];
+}
+
+export class AzureAuthStrategyConfig extends OAuth2AuthStrategyConfig {
+  /**
+   *  Users not belonging to any groups will receive this authority.
+   *  If not set, will be treated as if it was READ_ONLY
+   *  */
+  defaultUserAuthorityId: AuthorityId;
+  /**
+   * mapping of Azure Active Directory Groups to authority levels
+   * users should receive the highest applicable authorityId from the groups they're in
+   * or the default if they are in none.
+   * */
+  groupAuthorities?: {
+    groupId: string;
+    authorityId: AuthorityId;
+  }[];
+
 }
 
 export class LDAPAuthStrategyConfig extends AuthStrategyConfig{
@@ -36,7 +55,7 @@ export class LDAPAuthStrategyConfig extends AuthStrategyConfig{
   };
 }
 
-export class AuthConfiguration {
+export class AuthConfiguration<T = OAuth2AuthStrategyConfig | LDAPAuthStrategyConfig> {
   id:               number;
   authName:         string;
   authType:         AuthenticationType;
@@ -50,7 +69,7 @@ export class AuthConfiguration {
       ]
     }
   })
-  authConfig:       OAuth2AuthStrategyConfig | LDAPAuthStrategyConfig;
+  authConfig:       T;
   isRedirectable:   boolean;
   inSiteCredential: boolean;
   isActive:         boolean;

--- a/dash/backend/src/modules/auth/services/interfaces/Azure/directory-group.ts
+++ b/dash/backend/src/modules/auth/services/interfaces/Azure/directory-group.ts
@@ -1,0 +1,9 @@
+/**
+ * Partial interface of Directory Group object returned by graph memberOf endpoint.
+ * */
+export interface DirectoryGroup {
+  /** Unique Identifier for the group */
+  id: string;
+  /** Display name of the group */
+  displayName: string;
+}

--- a/dash/backend/src/modules/user/services/user-profile.service.ts
+++ b/dash/backend/src/modules/user/services/user-profile.service.ts
@@ -5,8 +5,9 @@ import {SourceSystem, UserAuthority, UserListDto, UserProfileDto} from '../dto/u
 import {UserCreateDto} from '../dto/user-create-dto';
 import {ResetPasswordService} from '../../auth/services/reset-password.service';
 import * as bcrypt from 'bcryptjs';
-import { Authority } from "../enum/Authority";
+import { Authority } from '../enum/Authority';
 import { PrometheusV1Service } from '../../metrics/services/prometheus-v1.service';
+import {AuthorityId} from '../enum/authority-id';
 
 
 @Injectable()
@@ -144,5 +145,22 @@ export class UserProfileService {
 
   async getUserFailedAttemptCountInLastHour(userId: number): Promise<number> {
     return await this.userDao.getUserFailedAttemptCount(userId);
+  }
+
+  /**
+   * Expects all authority ids to be a user-relevant type.
+   * returns null if no applicable types can be found
+   * */
+  maxUserAuthorityLevel(...authorities: AuthorityId[]): AuthorityId {
+    if (authorities?.some(a => a === AuthorityId.SUPER_ADMIN)) {
+      return AuthorityId.SUPER_ADMIN;
+    }
+    if (authorities?.some(a => a === AuthorityId.ADMIN)) {
+      return AuthorityId.ADMIN;
+    }
+    if (authorities?.some(a => a === AuthorityId.READ_ONLY)) {
+      return AuthorityId.READ_ONLY;
+    }
+    return null;
   }
 }

--- a/dash/frontend/src/app/core/entities/IAuth.ts
+++ b/dash/frontend/src/app/core/entities/IAuth.ts
@@ -54,6 +54,10 @@ export interface IOAUTHConfigStrategy {
 
 export interface IAzureConfigStrategy extends IOAUTHConfigStrategy {
   defaultAuthorityId: AuthorityId;
+  groupAuthorities?: {
+    groupId: string;
+    authorityId: AuthorityId;
+  }[];
 }
 
 export interface ILDAPConfigStrategy {

--- a/dash/frontend/src/app/core/entities/IAuth.ts
+++ b/dash/frontend/src/app/core/entities/IAuth.ts
@@ -1,4 +1,5 @@
 import {AuthenticationType} from '../enum/AuthenticationType';
+import {AuthorityId} from '../enum/Authority';
 
 export interface IAuth {
   accessToken: string;
@@ -49,6 +50,10 @@ export interface IOAUTHConfigStrategy {
   redirectUri: string;
   scopes: string[];
   allowedDomains: string[];
+}
+
+export interface IAzureConfigStrategy extends IOAUTHConfigStrategy {
+  defaultAuthorityId: AuthorityId;
 }
 
 export interface ILDAPConfigStrategy {

--- a/dash/frontend/src/app/core/entities/IAuthenticationMethod.ts
+++ b/dash/frontend/src/app/core/entities/IAuthenticationMethod.ts
@@ -1,7 +1,7 @@
 import {AuthenticationType} from '../enum/AuthenticationType';
 
 export interface IAuthenticationMethod {
-  id: string;
+  id: number;
   type: AuthenticationType;
   label: string;
   redirectable: boolean;

--- a/dash/frontend/src/app/core/enum/Authority.ts
+++ b/dash/frontend/src/app/core/enum/Authority.ts
@@ -3,6 +3,12 @@ export enum Authority {
     ADMIN = 'ADMIN',
     READ_ONLY = 'READ_ONLY'
 }
+
+export enum AuthorityId {
+  SUPER_ADMIN = 1,
+  ADMIN = 2,
+  READ_ONLY = 3
+}
 export const AuthorityValues = [
   Authority.SUPER_ADMIN,
   Authority.ADMIN,

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
@@ -108,37 +108,54 @@
           </mat-form-field>
         </div>
       </div>
-      <ng-container *ngFor="let gaForm of groupAuthorities.controls; let idx = index">
-        <form [formGroup]="gaForm">
-        <div class="group-authority-wrapper row">
-            <div class="col-sm-5 col-xs-12">
-              <mat-form-field>
-                <mat-label>Active Directory Group Id</mat-label>
-                <input formControlName="groupId" matInput>
-              </mat-form-field>
-            </div>
-            <div class="col-sm-5 col-xs-12">
-              <mat-form-field>
-                <mat-label>Authority Level</mat-label>
-                <mat-select formControlName="authorityId">
-                  <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
-                  <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
-                  <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-            <div class="col-sm-2 col-xs-12">
-              <button mat-icon-button><mat-icon>delete</mat-icon></button>
-            </div>
+      <div class="group-authority-wrapper p-xs-3">
+        <div class="row">
+          <div class="col-xs-12">
+            <h3>Grant Authority to Active Directory Groups</h3>
+            <p>
+              Users will receive the highest authority level granted by an active directory group they are a part of.
+              You will need to know the Object ID of a group to set this up.
+              You can find this id by
+              <a target="_blank" href="https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/groups-view-azure-portal#search-for-a-group">
+                searching for a group.
+              </a>
+            </p>
+          </div>
         </div>
-        </form>
-      </ng-container>
-      <div class="row">
-        <div class="col-xs-12 text-align-center">
-          <button mat-button mat-raised-button color="primary" type="button" (click)="addGroupAuthority()">
-            <mat-icon>add_circle</mat-icon>
-            Add Another
-          </button>
+        <ng-container *ngFor="let gaForm of groupAuthorities.controls; let idx = index">
+          <form [formGroup]="gaForm">
+          <div class="row">
+              <div class="col-sm-5 col-xs-12">
+                <mat-form-field>
+                  <mat-label>Active Directory Group Id</mat-label>
+                  <input formControlName="groupId" matInput>
+                </mat-form-field>
+              </div>
+              <div class="col-sm-5 col-xs-12">
+                <mat-form-field>
+                  <mat-label>Authority Level</mat-label>
+                  <mat-select formControlName="authorityId">
+                    <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
+                    <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
+                    <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div class="col-sm-2 col-xs-12">
+                <button mat-icon-button (click)="removeGroupAuthority(idx)">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
+          </div>
+          </form>
+        </ng-container>
+        <div class="row">
+          <div class="col-xs-12 text-align-center">
+            <button mat-button mat-raised-button color="primary" type="button" (click)="addGroupAuthority()">
+              <mat-icon>add_circle</mat-icon>
+              Add Group
+            </button>
+          </div>
         </div>
       </div>
     </ng-container>

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
@@ -72,6 +72,21 @@
         <mat-hint>Email domains allowed access to this application e.g. "example.com" to allow "user@example.com"</mat-hint>
       </mat-form-field>
     </p>
+    <ng-container *ngIf="authConfigForm.get('providerType').value === 'AZURE'">
+      <p>
+        <mat-form-field>
+          <mat-label>Default Authority Level</mat-label>
+          <mat-select formControlName="defaultAuthorityId">
+            <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
+            <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
+            <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
+          </mat-select>
+          <mat-hint>
+            Users will be granted this authority level unless they have an authority level granted by their AD Groups
+          </mat-hint>
+        </mat-form-field>
+      </p>
+    </ng-container>
   </ng-container>
 
   <ng-container *ngIf="ldapAuthActivated">

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
@@ -1,202 +1,279 @@
 <h1 mat-dialog-title>{{data.isEdit ? 'Update' : 'Add'}} Sign On Method</h1>
 
 <form mat-dialog-content [formGroup]="authConfigForm"  (ngSubmit)="onSubmit()" id="external-auth-conf-form">
-  <p>
-    <mat-form-field>
-      <mat-label>Auth Type</mat-label>
-      <mat-select formControlName="authType" (selectionChange)="activateAuthTypeFields()" >
-        <mat-option *ngFor="let authType of staticAuthTypeList" [value]="authType.value" [disabled]="authType.value === authenticationType.LOCAL">{{ authType.label }} </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </p>
-  <p *ngIf="!oauthAuthActivated">
-    <mat-form-field>
-      <mat-label>Provider Type</mat-label>
-      <input formControlName="providerType" matInput>
-    </mat-form-field>
-  </p>
-  <p *ngIf="oauthAuthActivated">
-    <mat-form-field>
-      <mat-label>Provider Type</mat-label>
-      <mat-select formControlName="providerType" (selectionChange)="onOAuthProviderTypeChange($event)">
-        <mat-option value="GOOGLE">Google</mat-option>
-        <mat-option value="AZURE">Azure</mat-option>
-      </mat-select>
-    </mat-form-field>
-  </p>
-  <p>
-    <mat-form-field>
-      <mat-label>Auth Name</mat-label>
-      <input formControlName="authName" matInput>
-    </mat-form-field>
-  </p>
-  <ng-container *ngIf="oauthAuthActivated">
-    <p>
+  <div class="row">
+    <div class="col-xs-12">
       <mat-form-field>
-        <mat-label>Client Id</mat-label>
-        <input formControlName="oauthClientId" matInput>
+        <mat-label>Auth Type</mat-label>
+        <mat-select formControlName="authType" (selectionChange)="activateAuthTypeFields()" >
+          <mat-option *ngFor="let authType of staticAuthTypeList" [value]="authType.value" [disabled]="authType.value === authenticationType.LOCAL">{{ authType.label }} </mat-option>
+        </mat-select>
       </mat-form-field>
-    </p>
+    </div>
+  </div>
+  <div *ngIf="!oauthAuthActivated">
+    <div class="col-xs-12">
+      <mat-form-field>
+        <mat-label>Provider Type</mat-label>
+        <input formControlName="providerType" matInput>
+      </mat-form-field>
+    </div>
+  </div>
+  <div class="row" *ngIf="oauthAuthActivated">
+    <div class="col-xs-12">
+      <mat-form-field>
+        <mat-label>Provider Type</mat-label>
+        <mat-select formControlName="providerType" (selectionChange)="onOAuthProviderTypeChange($event)">
+          <mat-option value="GOOGLE">Google</mat-option>
+          <mat-option value="AZURE">Azure</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <mat-form-field>
+        <mat-label>Auth Name</mat-label>
+        <input formControlName="authName" matInput>
+      </mat-form-field>
+    </div>
+  </div>
+  <ng-container *ngIf="oauthAuthActivated">
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Client Id</mat-label>
+          <input formControlName="oauthClientId" matInput>
+        </mat-form-field>
+      </div>
+    </div>
 
     <ng-container *ngIf="authConfigForm.get('providerType').value === 'GOOGLE'">
-      <p>
-        <mat-form-field>
-          <mat-label>Client Secret</mat-label>
-          <input formControlName="oauthClientSecret" matInput>
-        </mat-form-field>
-      </p>
-      <p>
-        <mat-form-field>
-          <mat-label>Access Token Uri</mat-label>
-          <input formControlName="oauthAccessTokenUri" matInput>
-        </mat-form-field>
-      </p>
+      <div class="row">
+        <div class="col-xs-12">
+          <mat-form-field>
+            <mat-label>Client Secret</mat-label>
+            <input formControlName="oauthClientSecret" matInput>
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <mat-form-field>
+            <mat-label>Access Token Uri</mat-label>
+            <input formControlName="oauthAccessTokenUri" matInput>
+          </mat-form-field>
+        </div>
+      </div>
     </ng-container>
 
-    <p>
-      <mat-form-field>
-        <mat-label>Authorization Uri</mat-label>
-        <input formControlName="oauthAuthorizationUri" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Access Scopes (comma separated)</mat-label>
-        <input formControlName="oauthScopes" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Allowed User Domains (comma separated)</mat-label>
-        <input formControlName="oauthAllowedDomains" matInput>
-        <mat-hint>Email domains allowed access to this application e.g. "example.com" to allow "user@example.com"</mat-hint>
-      </mat-form-field>
-    </p>
-    <ng-container *ngIf="authConfigForm.get('providerType').value === 'AZURE'">
-      <p>
+    <div class="row">
+      <div class="col-xs-12">
         <mat-form-field>
-          <mat-label>Default Authority Level</mat-label>
-          <mat-select formControlName="defaultAuthorityId">
-            <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
-            <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
-            <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
-          </mat-select>
-          <mat-hint>
-            Users will be granted this authority level unless they have an authority level granted by their AD Groups
-          </mat-hint>
+          <mat-label>Authorization Uri</mat-label>
+          <input formControlName="oauthAuthorizationUri" matInput>
         </mat-form-field>
-      </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Access Scopes (comma separated)</mat-label>
+          <input formControlName="oauthScopes" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Allowed User Domains (comma separated)</mat-label>
+          <input formControlName="oauthAllowedDomains" matInput>
+          <mat-hint>Email domains allowed access to this application e.g. "example.com" to allow "user@example.com"</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <ng-container *ngIf="authConfigForm.get('providerType').value === 'AZURE'">
+      <div class="row">
+        <div class="col-xs-12">
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>Default Authority Level</mat-label>
+            <mat-select formControlName="defaultAuthorityId">
+              <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
+              <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
+              <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
+            </mat-select>
+            <mat-hint>
+              Users will be granted this authority level unless they have an authority level granted by their AD Groups
+            </mat-hint>
+          </mat-form-field>
+        </div>
+      </div>
+      <ng-container *ngFor="let gaForm of groupAuthorities.controls; let idx = index">
+        <form [formGroup]="gaForm">
+        <div class="group-authority-wrapper row">
+            <div class="col-sm-5 col-xs-12">
+              <mat-form-field>
+                <mat-label>Active Directory Group Id</mat-label>
+                <input formControlName="groupId" matInput>
+              </mat-form-field>
+            </div>
+            <div class="col-sm-5 col-xs-12">
+              <mat-form-field>
+                <mat-label>Authority Level</mat-label>
+                <mat-select formControlName="authorityId">
+                  <mat-option [value]="AuthorityId.READ_ONLY">Read Only</mat-option>
+                  <mat-option [value]="AuthorityId.ADMIN">Admin</mat-option>
+                  <mat-option [value]="AuthorityId.SUPER_ADMIN">Super Admin</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-sm-2 col-xs-12">
+              <button mat-icon-button><mat-icon>delete</mat-icon></button>
+            </div>
+        </div>
+        </form>
+      </ng-container>
+      <div class="row">
+        <div class="col-xs-12 text-align-center">
+          <button mat-button mat-raised-button color="primary" type="button" (click)="addGroupAuthority()">
+            <mat-icon>add_circle</mat-icon>
+            Add Another
+          </button>
+        </div>
+      </div>
     </ng-container>
   </ng-container>
 
   <ng-container *ngIf="ldapAuthActivated">
-    <p>
-      <mat-form-field>
-        <mat-label>URL</mat-label>
-        <input formControlName="ldapUrl" matInput>
-        <mat-hint>ex: ldap://example.org</mat-hint>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>User Search Base</mat-label>
-        <input formControlName="ldapUserSearchBase" matInput>
-        <mat-hint>ex: dc=example,dc=org</mat-hint>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Username Attribute</mat-label>
-        <input formControlName="ldapUserNameAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Admin DN</mat-label>
-        <input formControlName="adminDn" matInput>
-        <mat-hint>ex: cn=admin,dc=example,dc=org</mat-hint>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Admin Password</mat-label>
-        <input formControlName="adminPassword" matInput [type]="ldapPasswordHide ? 'password' : 'text'">
-        <mat-icon matSuffix (click)="ldapPasswordHide = !ldapPasswordHide">{{ldapPasswordHide ? 'visibility_off' : 'visibility'}}</mat-icon>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Default User Authority</mat-label>
-        <mat-select formControlName="defaultUserAuthority">
-          <mat-option [value]="0">None</mat-option>
-          <mat-option [value]="1">View Only</mat-option>
-          <mat-option [value]="2">Admin</mat-option>
-          <mat-option [value]="3">Super Admin</mat-option>
-        </mat-select>
-        <mat-hint>select 'None' to prevent users not part of a valid group from logging on</mat-hint>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Group Search Base</mat-label>
-        <input formControlName="groupSearchBase" matInput>
-        <mat-hint>ex: ou=groups,dc=example,dc=org</mat-hint>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Class</mat-label>
-        <input formControlName="groupClass" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Member Attribute</mat-label>
-        <input formControlName="groupMemberAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Member User Attribute</mat-label>
-        <input formControlName="groupMemberUserAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Auth Level Attribute</mat-label>
-        <input formControlName="groupAuthLevelAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Auth View Only Value</mat-label>
-        <input formControlName="groupViewOnlyAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Auth Admin Value</mat-label>
-        <input formControlName="groupAdminAttribute" matInput>
-      </mat-form-field>
-    </p>
-    <p>
-      <mat-form-field>
-        <mat-label>Group Auth Super Admin Value</mat-label>
-        <input formControlName="groupSuperAdminAttribute" matInput>
-      </mat-form-field>
-    </p>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>URL</mat-label>
+          <input formControlName="ldapUrl" matInput>
+          <mat-hint>ex: ldap://example.org</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>User Search Base</mat-label>
+          <input formControlName="ldapUserSearchBase" matInput>
+          <mat-hint>ex: dc=example,dc=org</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Username Attribute</mat-label>
+          <input formControlName="ldapUserNameAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Admin DN</mat-label>
+          <input formControlName="adminDn" matInput>
+          <mat-hint>ex: cn=admin,dc=example,dc=org</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Admin Password</mat-label>
+          <input formControlName="adminPassword" matInput [type]="ldapPasswordHide ? 'password' : 'text'">
+          <mat-icon matSuffix (click)="ldapPasswordHide = !ldapPasswordHide">{{ldapPasswordHide ? 'visibility_off' : 'visibility'}}</mat-icon>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Default User Authority</mat-label>
+          <mat-select formControlName="defaultUserAuthority">
+            <mat-option [value]="0">None</mat-option>
+            <mat-option [value]="1">View Only</mat-option>
+            <mat-option [value]="2">Admin</mat-option>
+            <mat-option [value]="3">Super Admin</mat-option>
+          </mat-select>
+          <mat-hint>select 'None' to prevent users not part of a valid group from logging on</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Group Search Base</mat-label>
+          <input formControlName="groupSearchBase" matInput>
+          <mat-hint>ex: ou=groups,dc=example,dc=org</mat-hint>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Class</mat-label>
+          <input formControlName="groupClass" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Member Attribute</mat-label>
+          <input formControlName="groupMemberAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Member User Attribute</mat-label>
+          <input formControlName="groupMemberUserAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Auth Level Attribute</mat-label>
+          <input formControlName="groupAuthLevelAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Auth View Only Value</mat-label>
+          <input formControlName="groupViewOnlyAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Auth Admin Value</mat-label>
+          <input formControlName="groupAdminAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <mat-form-field>
+          <mat-label>Group Auth Super Admin Value</mat-label>
+          <input formControlName="groupSuperAdminAttribute" matInput>
+        </mat-form-field>
+      </div>
+    </div>
   </ng-container>
-  <p>
-    <!--        <mat-checkbox formControlName="isRedirectable" class="checkbox-margin">Redirectable</mat-checkbox>-->
-    <!--        <mat-checkbox formControlName="inSiteCredential" class="checkbox-margin">In Site Credential</mat-checkbox>-->
-    <mat-checkbox formControlName="isActive" class="checkbox-margin">Active</mat-checkbox>
-  </p>
-  <!--      <p>-->
-  <!--        <mat-checkbox formControlName="inSiteCredential" class="checkbox-margin">In Site Credential</mat-checkbox>-->
-  <!--      </p>-->
-  <!--      <p>-->
-  <!--        <mat-checkbox formControlName="isActive" class="checkbox-margin">Active</mat-checkbox>-->
-  <!--      </p>-->
+  <div class="row">
+    <div class="col-xs-12">
+      <mat-checkbox formControlName="isActive" class="checkbox-margin">Active</mat-checkbox>
+    </div>
+  </div>
 </form>
 
 <div mat-dialog-actions>

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.scss
@@ -4,6 +4,5 @@
 }
 
 .group-authority-wrapper {
-  //@TODO: style
-  // border-bottom: 1px grey solid;
+   border: 1px grey solid;
 }

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.scss
@@ -2,3 +2,8 @@
   position: static;
   margin-bottom: 15px;
 }
+
+.group-authority-wrapper {
+  //@TODO: style
+  // border-bottom: 1px grey solid;
+}

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
@@ -1,7 +1,7 @@
 import {Component, Inject, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ExternalAuthConfigurationService} from '../../../../../core/services/external-auth-configuration.service';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {FormArray, FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {AlertService} from 'src/app/core/services/alert.service';
 import {
   IAuthConfig,
@@ -28,6 +28,10 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
   ldapPasswordHide = true;
   // Make enum accessible to HTML
   AuthorityId = AuthorityId;
+
+  get groupAuthorities(): FormArray {
+    return this.authConfigForm.controls.groupAuthorities as FormArray;
+  }
 
   constructor(
     private dialogRef: MatDialogRef<ExternalAuthConfigurationCreateComponent>,
@@ -65,7 +69,8 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
       groupViewOnlyAttribute: [''],
       groupAdminAttribute: [''],
       groupSuperAdminAttribute: [''],
-      defaultAuthorityId: [AuthorityId.READ_ONLY]
+      defaultAuthorityId: [AuthorityId.READ_ONLY],
+      groupAuthorities: this.formBuilder.array([])
     });
   }
 
@@ -224,6 +229,13 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
         this.authConfigForm.controls.groupSuperAdminAttribute.setValue(ldapConfig.groupAuthLevelMapping.superAdmin);
         break;
     }
+  }
+
+  addGroupAuthority(values?: { groupId?: string, authorityId?: AuthorityId}): void {
+    this.groupAuthorities.push(this.formBuilder.group({
+      groupId: [values?.groupId || '', Validators.required],
+      authorityId: [values?.authorityId || AuthorityId.READ_ONLY, Validators.required]
+    }));
   }
 
   private stringToArray(commaSeparatedList) {

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
@@ -3,8 +3,14 @@ import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ExternalAuthConfigurationService} from '../../../../../core/services/external-auth-configuration.service';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {AlertService} from 'src/app/core/services/alert.service';
-import {IAuthConfig, ILDAPConfigStrategy, IOAUTHConfigStrategy} from '../../../../../core/entities/IAuth';
+import {
+  IAuthConfig,
+  IAzureConfigStrategy,
+  ILDAPConfigStrategy,
+  IOAUTHConfigStrategy
+} from '../../../../../core/entities/IAuth';
 import {AuthenticationType} from '../../../../../core/enum/AuthenticationType';
+import {AuthorityId} from '../../../../../core/enum/Authority';
 
 @Component({
   selector: 'app-external-auth-configuration-create',
@@ -20,6 +26,8 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
   oauthAuthActivated = false;
   ldapAuthActivated = false;
   ldapPasswordHide = true;
+  // Make enum accessible to HTML
+  AuthorityId = AuthorityId;
 
   constructor(
     private dialogRef: MatDialogRef<ExternalAuthConfigurationCreateComponent>,
@@ -57,6 +65,7 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
       groupViewOnlyAttribute: [''],
       groupAdminAttribute: [''],
       groupSuperAdminAttribute: [''],
+      defaultAuthorityId: [AuthorityId.READ_ONLY]
     });
   }
 
@@ -115,7 +124,8 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
           authorizationUri: this.authConfigForm.value.oauthAuthorizationUri,
           scopes: this.stringToArray(this.authConfigForm.value.oauthScopes),
           allowedDomains: this.stringToArray(this.authConfigForm.value.oauthAllowedDomains),
-        } as IOAUTHConfigStrategy) : ({
+          defaultAuthorityId: this.authConfigForm.value.defaultAuthorityId
+        } as IAzureConfigStrategy) : ({
           clientId: this.authConfigForm.value.oauthClientId,
           clientSecret: this.authConfigForm.value.oauthClientSecret,
           accessTokenUri: this.authConfigForm.value.oauthAccessTokenUri,
@@ -183,6 +193,11 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
         if (this.data.authConfigData.providerType === 'GOOGLE') {
           this.authConfigForm.controls.oauthClientSecret.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).clientSecret);
           this.authConfigForm.controls.oauthAccessTokenUri.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).accessTokenUri);
+        } else if (this.data.authConfigData.providerType === 'AZURE') {
+          const azureConfig = this.data.authConfigData.authConfig as IAzureConfigStrategy;
+          if (azureConfig.defaultAuthorityId) {
+            this.authConfigForm.controls.defaultAuthorityId.setValue(azureConfig.defaultAuthorityId);
+          }
         }
         this.authConfigForm.controls.oauthAuthorizationUri.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).authorizationUri);
         this.authConfigForm.controls.oauthScopes.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).scopes.join(','));

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.ts
@@ -129,7 +129,8 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
           authorizationUri: this.authConfigForm.value.oauthAuthorizationUri,
           scopes: this.stringToArray(this.authConfigForm.value.oauthScopes),
           allowedDomains: this.stringToArray(this.authConfigForm.value.oauthAllowedDomains),
-          defaultAuthorityId: this.authConfigForm.value.defaultAuthorityId
+          defaultAuthorityId: this.authConfigForm.value.defaultAuthorityId,
+          groupAuthorities: this.authConfigForm.value.groupAuthorities?.filter(ga => ga.groupId) || []
         } as IAzureConfigStrategy) : ({
           clientId: this.authConfigForm.value.oauthClientId,
           clientSecret: this.authConfigForm.value.oauthClientSecret,
@@ -203,6 +204,11 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
           if (azureConfig.defaultAuthorityId) {
             this.authConfigForm.controls.defaultAuthorityId.setValue(azureConfig.defaultAuthorityId);
           }
+          if (azureConfig.groupAuthorities?.length) {
+            for (const ga of azureConfig.groupAuthorities) {
+              this.addGroupAuthority(ga);
+            }
+          }
         }
         this.authConfigForm.controls.oauthAuthorizationUri.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).authorizationUri);
         this.authConfigForm.controls.oauthScopes.setValue((this.data.authConfigData.authConfig as IOAUTHConfigStrategy).scopes.join(','));
@@ -233,9 +239,13 @@ export class ExternalAuthConfigurationCreateComponent implements OnInit {
 
   addGroupAuthority(values?: { groupId?: string, authorityId?: AuthorityId}): void {
     this.groupAuthorities.push(this.formBuilder.group({
-      groupId: [values?.groupId || '', Validators.required],
+      groupId: [values?.groupId || ''],
       authorityId: [values?.authorityId || AuthorityId.READ_ONLY, Validators.required]
     }));
+  }
+
+  removeGroupAuthority(index: number): void {
+    this.groupAuthorities.removeAt(index);
   }
 
   private stringToArray(commaSeparatedList) {

--- a/selenium-testing/package-lock.json
+++ b/selenium-testing/package-lock.json
@@ -13,7 +13,7 @@
 				"@wdio/junit-reporter": "^8.15.0",
 				"@wdio/local-runner": "^8.15.0",
 				"@wdio/spec-reporter": "^8.15.0",
-				"chromedriver": "^115.0.1",
+				"chromedriver": "^116.0.0",
 				"dotenv": "^16.3.1",
 				"ts-node": "^10.9.1",
 				"typescript": "^5.1.6",
@@ -3806,9 +3806,9 @@
 			}
 		},
 		"node_modules/chromedriver": {
-			"version": "115.0.1",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
-			"integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
+			"version": "116.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
+			"integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -12828,9 +12828,9 @@
 			}
 		},
 		"chromedriver": {
-			"version": "115.0.1",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
-			"integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
+			"version": "116.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
+			"integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
 			"dev": true,
 			"requires": {
 				"@testim/chrome-version": "^1.1.3",

--- a/selenium-testing/package.json
+++ b/selenium-testing/package.json
@@ -9,7 +9,7 @@
 		"@wdio/junit-reporter": "^8.15.0",
 		"@wdio/local-runner": "^8.15.0",
 		"@wdio/spec-reporter": "^8.15.0",
-		"chromedriver": "^115.0.1",
+		"chromedriver": "^116.0.0",
 		"dotenv": "^16.3.1",
 		"ts-node": "^10.9.1",
 		"typescript": "^5.1.6",


### PR DESCRIPTION
# Extra fields for Azure OAuth config
Azure OAuth now has 2 extra (optional) fields, and they are configurable in the add/edit sign on method dialog.
## defaultAuthorityId
the ID of the authority level given to users not assigned an authority level by an AD group. Will be treated as if it was read only if not set.
## groupAuthorities 
An array of objects containing an authorityId and a groupId.
If a user is part of an AD group with an ID specified in this array, they are eligible for the associated authority.

# Granting Authorities
When a user signs in for the first time with Azure Auth, they will be created with the appropriate Authority Level based on these mappings. When a used signs in with their already created Azure account, their authority will be checked. If it is different than what it should be, it will be changed.

Either way the rules for determining which authority level is:
1. If the user is part of at least one AD group that is associated with an authority level, they will get the highest authority level amongst them. (Note that this can mean they have a lower privilege the defaultAuthorityId if they are part of only AD groups with lower authority levels)
2. If the user is not part of an AD group that grants privileges, and defaultAuthorityId is set on the config, they will receive that authority level.
3. If defaultAuthorityId is not set, and they aren't granted an authority from their AD groups, they will be Read Only users.

# Other
## Log in page saves auth method selection
Did for convenience in testing and thought it would be a feature. After changing the authentication method, will now save your selection to local storage and auto select it when you return to the sign in page.

## Use rows/cols for sign in method add/edit form
Converted the add/edit sign in method modal to use rows/cols instead of paragraphs, so that I could better make the styles for the additions of the new fields

