### PR TITLE
Print Reports Cleanup 1

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/reports/historical-vulnerabilities/historical-vulnerabilities.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/historical-vulnerabilities/historical-vulnerabilities.component.html
@@ -71,7 +71,7 @@
               <button (click)="downloadReport()"
                       mat-mini-fab
                       color="primary"
-                      class="mb-half-rem"
+                      class="mb-half-rem display-print-none"
                       matTooltip="Download Report"
                       type="button"><mat-icon>save_alt</mat-icon>
               </button>

--- a/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/running-vulnerabilities/running-vulnerabilities.component.html
@@ -73,7 +73,7 @@
             <div class="col-xs-10 vulnerability-count">
               <p class="title-font title-margin">Displaying {{lowNumCurrentShownVulnerabilities}}-{{highNumCurrentShownVulnerabilities}} out of {{vulnerabilityCount}} vulnerabilities</p>
             </div>
-            <div class="col-xs-2 vulnerability-download-button">
+            <div class="col-xs-2 vulnerability-download-button display-print-none">
               <button (click)="downloadReport()"
                       mat-mini-fab
                       color="primary"
@@ -151,7 +151,7 @@
             </mat-table>
           </div>
         </mat-card-content>
-        <mat-card-footer>
+        <mat-card-footer class="display-print-none">
           <mat-paginator
             [length]="vulnerabilityCount"
             [pageSize]="20"

--- a/dash/frontend/src/app/modules/private/pages/reports/vulnerability-difference-by-date/vulnerability-difference-by-date.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/vulnerability-difference-by-date/vulnerability-difference-by-date.component.html
@@ -80,6 +80,7 @@
                 <div class="col-xs-6 no-padding vulnerability-download-button report-settings-download-button">
                   <button [disabled]="!previousRequest"
                           (click)="downloadReport()"
+                          class="display-print-none"
                           mat-raised-button
                           color="primary"
                           type="button">Download

--- a/dash/frontend/src/app/modules/private/pages/reports/vulnerability-export/vulnerability-export.component.html
+++ b/dash/frontend/src/app/modules/private/pages/reports/vulnerability-export/vulnerability-export.component.html
@@ -81,10 +81,10 @@
       <mat-card>
         <mat-card-header>
           <div class="row full-width">
-            <div class="col-xs-10">
+            <div class="col-xs-10 display-print-block">
               <p class="title-font vulnerabilities-title">Displaying {{limit}} out of {{vulnerabilityCount}} vulnerabilities</p>
             </div>
-            <div class="col-xs-2 vulnerability-download-button">
+            <div class="col-xs-2 vulnerability-download-button display-print-none">
               <button (click)="downloadReport()"
                       mat-mini-fab
                       color="primary"

--- a/dash/frontend/src/app/modules/private/private.component.html
+++ b/dash/frontend/src/app/modules/private/private.component.html
@@ -59,7 +59,7 @@
   </mat-menu>
 </mat-toolbar>
 
-<div class="display-print-none" style="height: 50px"></div>
+<div class="display-print-none" style="height: 50px">&nbsp</div>
 <div class="main-content">
   <app-menu-component #sidenav></app-menu-component>
 </div>

--- a/dash/frontend/src/app/modules/private/private.component.html
+++ b/dash/frontend/src/app/modules/private/private.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar class="fixed">
+<mat-toolbar class="fixed display-print-none">
   <mat-toolbar-row class="header-bar">
     <div class="loader-row">
       <fa-icon
@@ -59,7 +59,7 @@
   </mat-menu>
 </mat-toolbar>
 
-<div style="height: 50px">&nbsp;</div>
+<div class="display-print-none" style="height: 50px"></div>
 <div class="main-content">
   <app-menu-component #sidenav></app-menu-component>
 </div>

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
@@ -2,6 +2,7 @@
   <mat-sidenav
     #sidenav
     id="primary-side-nav"
+    class="display-print-none"
     [attr.role]="isHandsetOrXS ? 'dialog' : 'navigation'"
     [mode]="isHandsetOrXS ? 'over' : 'side'"
     [opened]="(isHandsetOrXS === false) || sidenavExpanded"
@@ -76,7 +77,7 @@
     </mat-nav-list>
 
   </mat-sidenav>
-  <mat-sidenav-content style="height: 100%">
+  <mat-sidenav-content style="height: 100%" class="mx-print-0">
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/dash/frontend/src/generic-styles.scss
+++ b/dash/frontend/src/generic-styles.scss
@@ -130,7 +130,7 @@ $sides: (
   all: ['inline-start', 'top', 'inline-end', 'bottom'],
 );
 
-@mixin build-spacing-classes($breakpointShorthand: xs) {
+@mixin build-spacing-classes($breakpointShorthand: xs, $makeImportant: 'false') {
   $properties: (
     p: "padding",
     m: "margin",
@@ -153,8 +153,14 @@ $sides: (
       }
       @each $sizeShorthand, $size in $sizes {
         #{"."}#{$propertyShorthand}#{$sideShorthandToUse}-#{$breakpointShorthand}-#{$sizeShorthand} {
-          @each $side in $sideList {
-            #{$property}-#{$side}: #{$size};
+          @if $makeImportant == 'true' {
+            @each $side in $sideList {
+              #{$property}-#{$side}: #{$size} !important;
+            }
+          } @else {
+            @each $side in $sideList {
+              #{$property}-#{$side}: #{$size};
+            }
           }
         }
       }
@@ -200,6 +206,6 @@ $sides: (
 }
 
 @media print {
-  @include build-spacing-classes(print);
+  @include build-spacing-classes(print, 'true');
   @include generate-basic-classes(print);
 }

--- a/dash/frontend/src/generic-styles.scss
+++ b/dash/frontend/src/generic-styles.scss
@@ -163,6 +163,7 @@ $sides: (
 }
 
 @mixin generate-basic-classes($breakpointShorthand: xs) {
+  // @if $sideShorthand == 'all' {}
   @each $propertyName, $definition in $classesToGenerate {
     $propertyAbbreviation: map-get($definition, abbreviation);
     $usesSides: map-get($definition, usesSides);
@@ -196,4 +197,9 @@ $sides: (
 @media only screen and (min-width: 75em) {
   @include build-spacing-classes(lg);
   @include generate-basic-classes(lg);
+}
+
+@media print {
+  @include build-spacing-classes(print);
+  @include generate-basic-classes(print);
 }

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -827,3 +827,13 @@ app-datepicker-component {
 .overflow-hidden {
   overflow: hidden!important;
 }
+
+@media print {
+  @page {
+    size: landscape;
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
Print reports:
- add -print- to custom style generation
- add ability to include `!important` in custom style generation (defaults to false)
- hide navigation
- hide "download" buttons
- hide scrollbars in Chrome (+ possibly others - used webkit)