### PR TITLE
Print Reports Cleanup 2

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/add-template-constraint/add-template-constraint.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/add-template-constraint/add-template-constraint.component.html
@@ -100,16 +100,15 @@
       </div>
     </div>
 
-    <div class="row action-button-row">
-      <div id="action-btn">
-        <button [disabled]="!addTemplateConstraintForm.valid" (click)="onSubmit()" mat-raised-button color="primary"
-                type="submit" class="me-xs-2">
-          Save Changes
-        </button>
-        <button mat-raised-button color="warn" type="button" (click)="onNoClick()">Cancel</button>
+      <div class="row action-button-row">
+        <div id="action-btn">
+          <button [disabled]="!addTemplateConstraintForm.valid" (click)="onSubmit()" mat-raised-button color="primary"
+                  type="submit" class="me-xs-2">
+            Save Changes
+          </button>
+          <button mat-raised-button color="warn" type="button" (click)="onNoClick()">Cancel</button>
+        </div>
       </div>
     </div>
-
-  </div>
   </div>
 </mat-dialog-content>

--- a/dash/frontend/src/app/modules/private/pages/cluster/add-template-constraint/add-template-constraint.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/cluster/add-template-constraint/add-template-constraint.component.scss
@@ -37,3 +37,9 @@ h3 {
   background-color: pink;
 }
 
+.action-button-row {
+  display: flex;
+  justify-content: flex-end;
+  align-content: center;
+  margin-right: 5px;
+}

--- a/dash/frontend/src/app/modules/private/pages/reports/vulnerability-export/vulnerability-export.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/reports/vulnerability-export/vulnerability-export.component.scss
@@ -4,4 +4,7 @@
 
 .vulnerabilities-title  {
   padding-left: 21px;
+  @media print {
+    padding-left: 8px;
+  }
 }

--- a/dash/frontend/src/app/modules/private/pages/user/user-list/user-list.component.scss
+++ b/dash/frontend/src/app/modules/private/pages/user/user-list/user-list.component.scss
@@ -1,1 +1,1 @@
-@import 'src/styles';
+

--- a/dash/frontend/src/styles.scss
+++ b/dash/frontend/src/styles.scss
@@ -664,9 +664,8 @@ div.collapse-item {
   }
 }
 div.cluster-dashboard {
-  //width: calc(100% - 300px);
   flex-direction: column;
-  background-color: #e0e0e0;
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 300);
 }
 
 // RESPONSIVE - work for large screen to collapse or expand
@@ -721,13 +720,6 @@ div.cluster-dashboard.responsive {
 
 .flex-column {
   flex-direction: column;
-}
-
-.action-button-row {
-  display: flex;
-  justify-content: end;
-  align-content: center;
-  margin-right: 5px;
 }
 
 .light-border {
@@ -835,5 +827,15 @@ app-datepicker-component {
 
   ::-webkit-scrollbar {
     display: none;
+  }
+
+  #cluster-dashboard, .page-container {
+    background-color: white;
+  }
+  mat-card.mat-mdc-card {
+    box-shadow: unset !important;
+  }
+  .page-title {
+    margin-left: 14px;
   }
 }


### PR DESCRIPTION
- `add-template-constraint.component.html`: fix indentation
- `add-template-constraint.component.scss`: move page-specific style into the page's stylesheet
- `vulnerability-export.component.scss`: adjust title padding for print
- `user-list.component.scss`: remove unnecessary import
- `styles.scss`:
   - make `.cluster-dashboard` get the grey background color from the standard palette
   - for print:
      - make the background color white and remove the box shadowing on the cards
      - adjust the page title margin so it aligns with the card titles 