### PR TITLE
Speed up "Vulnerability Difference by Date" Endpoints

### DIFF
--- a/dash/backend/src/modules/image/dao/image.dao.ts
+++ b/dash/backend/src/modules/image/dao/image.dao.ts
@@ -524,6 +524,15 @@ export class ImageDao {
         if (filters['namespace']?.length > 0) {
             subQuery = subQuery.whereIn('history_kubernetes_images.namespace', filters['namespace']);
         }
+
+
+        if (filters.hasOwnProperty('startDate')) {
+          subQuery = subQuery.andWhere('history_kubernetes_images.saved_date', '>=', filters['startDate']);
+        }
+
+        if (filters.hasOwnProperty('endDate')) {
+          subQuery = subQuery.andWhere('history_kubernetes_images.saved_date', '<=', filters['endDate']);
+        }
         subQuery = subQuery.groupBy([
             'history_kubernetes_images.image',
             'history_kubernetes_images.image_hash',
@@ -576,6 +585,7 @@ export class ImageDao {
 
         query = query.orderBy('hki.saved_date', 'asc');
 
+        const rawSQL = query.toSQL();
         return query;
     }
 

--- a/dash/backend/src/modules/image/dao/image.dao.ts
+++ b/dash/backend/src/modules/image/dao/image.dao.ts
@@ -585,7 +585,6 @@ export class ImageDao {
 
         query = query.orderBy('hki.saved_date', 'asc');
 
-        const rawSQL = query.toSQL();
         return query;
     }
 

--- a/dash/backend/src/modules/reports/dao/reports.dao.ts
+++ b/dash/backend/src/modules/reports/dao/reports.dao.ts
@@ -43,7 +43,7 @@ export class ReportsDao {
             .andWhere('i.deleted_at', null)
             .andWhere('c.deleted_at', null);
         if (clusterId) {
-            subQuery = subQuery.andWhere('i.cluster_id', clusterId);
+            subQuery = subQuery.andWhere('hki.cluster_id', clusterId);
         }
         if (namespaces) {
             subQuery = subQuery.whereIn('ki.namespace', namespaces);
@@ -552,7 +552,7 @@ export class ReportsDao {
         .whereIn('hki.saved_date', [startDate, endDate]);
 
       if (clusterId) {
-        imageDetailsQuery.andWhere('i.cluster_id', clusterId);
+        imageDetailsQuery.andWhere('hki.cluster_id', clusterId);
       }
       if (namespaces) {
         imageDetailsQuery.whereIn('hki.namespace', namespaces);

--- a/dash/backend/src/modules/reports/services/reports.service.ts
+++ b/dash/backend/src/modules/reports/services/reports.service.ts
@@ -189,14 +189,25 @@ export class ReportsService {
         return this.reportsDao.getWorstImages(clusterId, startDate, endDate, namespaces);
     }
 
-    async getVulnerabilityDifferenceByDate(clusterId: number, startDate: string, endDate: string,
-                                           options?: {namespaces?: Array<string>,
-                                               severity?: Array<VulnerabilitySeverity>, fixAvailable?: string,
-                                               limit?: number})
-    : Promise<ReportsDifferenceByDateDto>
+    async getVulnerabilityDifferenceByDate(
+      clusterId: number, startDate: string, endDate: string,
+      options?: {
+        namespaces?: Array<string>,
+        severity?: Array<VulnerabilitySeverity>, fixAvailable?: string,
+        limit?: number
+    }): Promise<ReportsDifferenceByDateDto>
     {
-        return this.reportsDao.getDifferencesInVulnerabilities(startDate, endDate, clusterId, options?.namespaces,
-            options?.severity, options?.fixAvailable, options?.limit);
+        return Promise.all([
+            this.reportsDao.getVulnerabilityDifferenceSummaryByDate(startDate, endDate, clusterId, options?.namespaces, options?.severity, options?.fixAvailable),
+            this.reportsDao.getDifferencesInVulnerabilities(startDate, endDate, clusterId, options?.namespaces, options?.severity, options?.fixAvailable, options?.limit),
+        ]).then(values => {
+            return {
+                countOfFixedVulnerabilities: values[0].countOfFixedVulnerabilities,
+                countOfNewVulnerabilities: values[0].countOfNewVulnerabilities,
+                fixedVulnerabilities: values[1].fixedVulnerabilities,
+                newVulnerabilities: values[1].newVulnerabilities,
+            }
+        });
     }
 
     async getVulnerabilityDifferenceByDateCsv(clusterId: number, startDate: string, endDate: string,

--- a/dash/backend/src/modules/reports/services/reports.service.ts
+++ b/dash/backend/src/modules/reports/services/reports.service.ts
@@ -197,17 +197,7 @@ export class ReportsService {
         limit?: number
     }): Promise<ReportsDifferenceByDateDto>
     {
-        return Promise.all([
-            this.reportsDao.getVulnerabilityDifferenceSummaryByDate(startDate, endDate, clusterId, options?.namespaces, options?.severity, options?.fixAvailable),
-            this.reportsDao.getDifferencesInVulnerabilities(startDate, endDate, clusterId, options?.namespaces, options?.severity, options?.fixAvailable, options?.limit),
-        ]).then(values => {
-            return {
-                countOfFixedVulnerabilities: values[0].countOfFixedVulnerabilities,
-                countOfNewVulnerabilities: values[0].countOfNewVulnerabilities,
-                fixedVulnerabilities: values[1].fixedVulnerabilities,
-                newVulnerabilities: values[1].newVulnerabilities,
-            }
-        });
+        return this.reportsDao.getDifferencesInVulnerabilities(startDate, endDate, clusterId, options?.namespaces, options?.severity, options?.fixAvailable);
     }
 
     async getVulnerabilityDifferenceByDateCsv(clusterId: number, startDate: string, endDate: string,

--- a/dash/frontend/src/app/modules/private/pages/reports/vulnerability-difference-by-date/vulnerability-difference-by-date.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/reports/vulnerability-difference-by-date/vulnerability-difference-by-date.component.ts
@@ -7,7 +7,7 @@ import {ActivatedRoute} from '@angular/router';
 import {CustomValidatorService} from '../../../../../core/services/custom-validator.service';
 import {ImageService} from '../../../../../core/services/image.service';
 import {AlertService} from 'src/app/core/services/alert.service';
-import {format, isBefore} from 'date-fns';
+import {format, isBefore, parseISO} from 'date-fns';
 import {Subject} from 'rxjs';
 import {ChartSizeService} from '../../../../../core/services/chart-size.service';
 import {MatTableDataSource} from '@angular/material/table';
@@ -16,7 +16,7 @@ import {CsvService} from '../../../../../core/services/csv.service';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 import {EnumService} from '../../../../../core/services/enum.service';
 import {NgxUiLoaderConfig, NgxUiLoaderService, POSITION, SPINNER} from 'ngx-ui-loader';
-import {FormBuilder, FormGroup} from '@angular/forms';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 
 @Component({
@@ -42,6 +42,11 @@ import {FormBuilder, FormGroup} from '@angular/forms';
 })
 export class VulnerabilityDifferenceByDateComponent implements OnInit, OnDestroy {
   private unsubscribe$ = new Subject<void>();
+
+  today: Date;
+  yesterday: Date;
+  twoDaysAgo: Date;
+
   vulnerabilitySeverities: Array<VulnerabilitySeverity>;
   clusterNamespaces: Array<string>;
   clusterId: number;
@@ -93,7 +98,13 @@ export class VulnerabilityDifferenceByDateComponent implements OnInit, OnDestroy
     private csvService: CsvService,
     private enumService: EnumService,
     private loaderService: NgxUiLoaderService,
-  ) {}
+  ) {
+    this.today = new Date();
+    this.yesterday = new Date();
+    this.yesterday.setDate(this.today.getDate() - 1);
+    this.twoDaysAgo = new Date();
+    this.twoDaysAgo.setDate(this.today.getDate() - 2);
+  }
 
   ngOnInit() {
     this.route.parent.parent.params
@@ -116,8 +127,8 @@ export class VulnerabilityDifferenceByDateComponent implements OnInit, OnDestroy
       namespaces: [[]],
       severityLevels: [[]],
       fixAvailable: [],
-      startDate: ['', [this.customValidatorService.dateInPastOrToday]],
-      endDate: ['', [this.customValidatorService.dateInPastOrToday]]
+      startDate: [this.twoDaysAgo, [Validators.required, this.customValidatorService.dateInPastOrToday]],
+      endDate: [this.yesterday, [Validators.required, this.customValidatorService.dateInPastOrToday]]
     });
 
     this.setChartSize(true);
@@ -263,8 +274,10 @@ export class VulnerabilityDifferenceByDateComponent implements OnInit, OnDestroy
   }
 
   get filtersValid() {
+    const startDate = this.filterForm.get('startDate').value;
+    const endDate = this.filterForm.get('endDate').value;
     return this.filterForm.valid &&
-      isBefore(this.filterForm.get('startDate').value, this.filterForm.get('endDate').value);
+      isBefore(startDate, endDate);
   }
 
   setChartSize(isInitial = false) {


### PR DESCRIPTION
Frontend:
- report page: autofill dates for convenience

Backend:
- `image.dao.ts`: + subquery filtering to speed up graph
- `reports.dao.ts`: rework `getDifferencesInVulnerabilities` method
- `reports.service.ts`: spacing for `getVulnerabilityDifferenceByDate` method