### PR TITLE
Auth audit

### DIFF
--- a/dash/backend/src/modules/cluster/dao/cluster.dao.ts
+++ b/dash/backend/src/modules/cluster/dao/cluster.dao.ts
@@ -159,7 +159,7 @@ export class ClusterDao {
         return knex
             .where('id', +id)
             .update(deletedTime, ['id'])
-            .into('clusters')
+            .into('clusters');
     }
 
     async searchClusters(groupId: number, searchTerm: string): Promise<ClusterDto[]> {

--- a/dash/backend/src/modules/gatekeeper/controllers/gatekeeper-constraint-template.controller.ts
+++ b/dash/backend/src/modules/gatekeeper/controllers/gatekeeper-constraint-template.controller.ts
@@ -66,7 +66,7 @@ export class GatekeeperConstraintTemplateController {
   }
 
   @Get(':templateName')
-  @AllowedAuthorityLevels(Authority.SUPER_ADMIN, Authority.ADMIN)
+  @AllowedAuthorityLevels(Authority.SUPER_ADMIN, Authority.ADMIN, Authority.READ_ONLY)
   @UseGuards(AuthGuard, AuthorityGuard)
   @ApiResponse({
     status: 200,

--- a/dash/backend/src/modules/reports/controllers/reports.controller.ts
+++ b/dash/backend/src/modules/reports/controllers/reports.controller.ts
@@ -3,12 +3,10 @@ import {
     Controller,
     Get,
     Header,
-    Inject,
     Query,
     UseGuards,
     UseInterceptors
 } from '@nestjs/common';
-import { UserProfileDto } from '../../user/dto/user-profile-dto';
 import { AllowedAuthorityLevels } from '../../../decorators/allowed-authority-levels.decorator';
 import { Authority } from '../../user/enum/Authority';
 import { ReportsService } from '../services/reports.service';
@@ -26,13 +24,11 @@ import {format} from 'date-fns'
 @UseInterceptors(ResponseTransformerInterceptor)
 export class ReportsController {
     constructor(
-        @Inject('LOGGED_IN_USER')
-        private readonly _loggedInUser: UserProfileDto,
         private readonly reportsService: ReportsService,
     ) {}
 
     @Get('/vulnerability-export')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async getVulnerabilityExport(
         @Query('limit') limit: number,
@@ -50,7 +46,7 @@ export class ReportsController {
     }
 
     @Get('/vulnerability-export/download')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @Header('Content-Type', 'text/csv')
     @UseGuards(AuthGuard, AuthorityGuard)
     async downloadVulnerabilityExport(
@@ -65,7 +61,7 @@ export class ReportsController {
     }
 
     @Get('/running-vulnerabilities')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async getRunningVulnerabilities(
         @Query('limit') limit: number,
@@ -82,7 +78,7 @@ export class ReportsController {
     }
 
     @Get('/running-vulnerabilities/download')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @Header('Content-Type', 'text/csv')
     @UseGuards(AuthGuard, AuthorityGuard)
     async downloadRunningVulnerabilitiesReport(
@@ -95,7 +91,7 @@ export class ReportsController {
     }
 
     @Get('/historical-vulnerabilities')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async getHistoricalVulnerabilities(
         @Query('limit') limit: number,
@@ -119,7 +115,7 @@ export class ReportsController {
     }
 
     @Get('/worst-images')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async getWorstImages(
         @Query('cluster-id') clusterId?: number,
@@ -132,7 +128,7 @@ export class ReportsController {
     }
 
     @Get('/historical-vulnerabilities/download')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @Header('Content-Type', 'text/csv')
     @UseGuards(AuthGuard, AuthorityGuard)
     async downloadHistoricalVulnerabilitiesReport(
@@ -154,7 +150,7 @@ export class ReportsController {
     }
 
     @Get('/vulnerability-difference')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async getVulnerabilityDifferences(
         @Query('cluster-id') clusterId: number,
@@ -177,7 +173,7 @@ export class ReportsController {
     }
 
     @Get('/vulnerability-difference/download')
-    @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+    @AllowedAuthorityLevels(Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN)
     @UseGuards(AuthGuard, AuthorityGuard)
     async downloadVulnerabilityDifferences(
         @Query('cluster-id') clusterId: number,

--- a/dash/frontend/src/app/modules/private/menus/services/cluster-list-menu.service.ts
+++ b/dash/frontend/src/app/modules/private/menus/services/cluster-list-menu.service.ts
@@ -9,6 +9,7 @@ import {
   ClusterGroupCreateComponent
 } from '../../pages/cluster-group/cluster-group-create/cluster-group-create.component';
 import {take} from 'rxjs/operators';
+import {Authority} from '../../../../core/enum/Authority';
 
 @Injectable({
   providedIn: 'root'
@@ -84,7 +85,7 @@ export class ClusterListMenuService implements NavServiceInterface, OnDestroy {
       name: 'add-cluster-group',
       title: 'Add Cluster Group',
       icon: 'add',
-      adminsOnly: true,
+      allowedRoles: [Authority.ADMIN, Authority.SUPER_ADMIN],
       callback: this.openAddGroupDialog,
     }];
     this.currentMenuContentTriggers.next(this.menuContentTriggers);

--- a/dash/frontend/src/app/modules/private/menus/services/cluster-list-menu.service.ts
+++ b/dash/frontend/src/app/modules/private/menus/services/cluster-list-menu.service.ts
@@ -84,6 +84,7 @@ export class ClusterListMenuService implements NavServiceInterface, OnDestroy {
       name: 'add-cluster-group',
       title: 'Add Cluster Group',
       icon: 'add',
+      adminsOnly: true,
       callback: this.openAddGroupDialog,
     }];
     this.currentMenuContentTriggers.next(this.menuContentTriggers);

--- a/dash/frontend/src/app/modules/private/menus/services/settings-menu.service.ts
+++ b/dash/frontend/src/app/modules/private/menus/services/settings-menu.service.ts
@@ -52,7 +52,7 @@ export class SettingsMenuService implements NavServiceInterface, OnDestroy {
         name: 'Sign on Methods',
         path: ['/private', 'single-sign-on'],
         icon: 'vpn_key',
-        allowedRoles: [Authority.ADMIN, Authority.SUPER_ADMIN],
+        allowedRoles: [Authority.SUPER_ADMIN],
       },
       {
         name: 'Docker Registries',

--- a/dash/frontend/src/app/modules/private/pages/change-password/change-password.component.html
+++ b/dash/frontend/src/app/modules/private/pages/change-password/change-password.component.html
@@ -26,7 +26,7 @@
               <input matInput placeholder="Confirm password" type="password" formControlName="confirmPassword">
             </mat-form-field>
           </p>
-          <button [disabled]="!changePasswordForm.valid" mat-raised-button type="submit">Submit</button>
+          <button [disabled]="!changePasswordForm.valid" mat-raised-button type="submit" color="primary">Submit</button>
         </form>
       </mat-card-content>
     </mat-card>

--- a/dash/frontend/src/app/modules/private/pages/cluster/add-edit-constraint-template-manifest/add-edit-constraint-template-manifest.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/add-edit-constraint-template-manifest/add-edit-constraint-template-manifest.component.html
@@ -1,5 +1,5 @@
 <div mat-dialog-title>
-  Edit {{this.data?.subDir ? this.data.subDir : 'Constraint'}} Template
+  {{ readOnly ? 'View' : 'Edit' }} {{this.data?.subDir ? this.data.subDir : 'Constraint'}} Template
 </div>
 <mat-dialog-content>
   <ngx-codemirror #codemirror
@@ -13,7 +13,7 @@
       <button [disabled]="true" mat-raised-button color="primary" type="submit" style="display: none;">REgo IDE</button>
     </div>
     <div>
-      <button mat-raised-button color="primary" type="submit" (click)="deployCustomTemplate()">Save Changes</button>
+      <button mat-raised-button *ngIf="!readOnly" color="primary" type="submit" (click)="deployCustomTemplate()">Save Changes</button>
       <button mat-raised-button mat-dialog-close color="warn" type="button">Cancel</button>
     </div>
   </div>

--- a/dash/frontend/src/app/modules/private/pages/cluster/add-edit-constraint-template-manifest/add-edit-constraint-template-manifest.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/add-edit-constraint-template-manifest/add-edit-constraint-template-manifest.component.ts
@@ -4,6 +4,7 @@ import {AlertService} from 'src/app/core/services/alert.service';
 import {IGatekeeperConstraintTemplate} from '../../../../../core/entities/gatekeeper';
 import {GatekeeperService} from '../../../../../core/services/gatekeeper.service';
 import {take} from 'rxjs/operators';
+import {JwtAuthService} from '../../../../../core/services/jwt-auth.service';
 
 @Component({
   selector: 'app-add-edit-constraint-template-manifest',
@@ -12,6 +13,7 @@ import {take} from 'rxjs/operators';
 })
 export class AddEditConstraintTemplateManifestComponent implements OnInit {
   codeMirrorOptions: any = {
+    readOnly: false,
     theme: 'material',
     mode: {name: 'javascript', json: true},
     lineNumbers: true,
@@ -25,6 +27,7 @@ export class AddEditConstraintTemplateManifestComponent implements OnInit {
   };
   initialHeight = 300; // this is the initial height of codemirror
   rawTemplate: any;
+  readOnly: boolean;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: {
@@ -33,14 +36,19 @@ export class AddEditConstraintTemplateManifestComponent implements OnInit {
       templateName: string;
       saveTemplate?: boolean;
       subDir?: string;
+      readOnly: boolean;
     },
     private gatekeeperService: GatekeeperService,
     private dialogRef: MatDialogRef<AddEditConstraintTemplateManifestComponent>,
-    private alertService: AlertService
+    private alertService: AlertService,
+    protected readonly authService: JwtAuthService
   ) {}
 
   ngOnInit(): void {
     this.rawTemplate = JSON.stringify(this.data.templateContent, null, ' ');
+    // Readonly if in read only mode or not an admin
+    this.readOnly = this.data?.readOnly || !this.authService.isAdmin();
+    this.codeMirrorOptions.readOnly = this.readOnly;
   }
 
   deployCustomTemplate() {

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.html
@@ -5,9 +5,9 @@
         {{templateName}}
       </div>
       <div class="col-xs-12 col-sm-6 start-xs end-sm page-button-spacing">
-          <button [disabled]="!gatekeeperTemplate" class="me-xs-1" [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" mat-raised-button mat-button color="primary" (click)="editTemplate()">
-            <mat-icon>create</mat-icon>
-            Edit
+          <button [disabled]="!gatekeeperTemplate" class="me-xs-1" mat-raised-button mat-button color="primary" (click)="editTemplate()">
+            <mat-icon>{{isAdmin ? 'create' : 'visibility'}}</mat-icon>
+            {{isAdmin ? 'Edit' : 'View'}}
           </button>
           <button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" mat-raised-button mat-button color="warn" (click)="destroyConstraintTemplate()">
             <mat-icon>delete</mat-icon>

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
@@ -51,15 +51,25 @@ export class GateKeeperDetailsComponent implements OnInit {
     }
   }
 
+  /**
+   * If excludeConstraints is true, this will only load & update data relevant to the constraint template itself,
+   * and not update the table of Constraints
+   * */
   getConstraintTemplateDetails(excludeConstraints = false) {
-    this.gatekeeperService.getConstraintTemplateByName(this.clusterId, this.templateName, excludeConstraints).subscribe(data => {
-      this.gatekeeperTemplate = data.template;
+    this.gatekeeperService.getConstraintTemplateByName(this.clusterId, this.templateName, excludeConstraints)
+      .pipe(take(1))
+      .subscribe({
+        next: data => {
+          this.gatekeeperTemplate = data.template;
 
-      const associatedConstraints = data.associatedConstraints ?? [];
-      this.constraintCount = associatedConstraints.length ?? 0;
-      this.constraintsList = new MatTableDataSource<IGatekeeperConstraint>(associatedConstraints);
-      this.updateConstraintTemplateProperties();
-    });
+          if (!excludeConstraints) {
+            const associatedConstraints = data.associatedConstraints ?? [];
+            this.constraintCount = associatedConstraints.length ?? 0;
+            this.constraintsList = new MatTableDataSource<IGatekeeperConstraint>(associatedConstraints);
+          }
+          this.updateConstraintTemplateProperties();
+    }
+      });
   }
 
   updateConstraintTemplateProperties() {
@@ -120,6 +130,7 @@ export class GateKeeperDetailsComponent implements OnInit {
       .pipe(take(1))
       .subscribe(response => {
         if (response && response.editedTemplate) {
+          console.log('hereere');
           this.getConstraintTemplateDetails(true);
         }
     });

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
@@ -132,7 +132,6 @@ export class GateKeeperDetailsComponent implements OnInit {
       .pipe(take(1))
       .subscribe(response => {
         if (response && response.editedTemplate) {
-          console.log('hereere');
           this.getConstraintTemplateDetails(true);
         }
     });

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper-details/gate-keeper-details.component.ts
@@ -28,6 +28,7 @@ export class GateKeeperDetailsComponent implements OnInit {
   displayedColumns: string[];
   openapiProperties = [];
   openApiSchema: any;
+  isAdmin: boolean;
 
   constructor(
     private readonly gateKeeperService: GateKeeperService,
@@ -44,7 +45,8 @@ export class GateKeeperDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.getConstraintTemplateDetails();
-    if (this.jwtAuthService.isAdmin()) {
+    this.isAdmin = this.jwtAuthService.isAdmin();
+    if (this.isAdmin) {
       this.displayedColumns = ['name', 'description', 'mode', 'action', 'violations'];
     } else {
       this.displayedColumns = ['name', 'description', 'mode', 'violations'];

--- a/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper/gate-keeper.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/gate-keeper/gate-keeper.component.html
@@ -39,11 +39,11 @@
 
               <div class="col-xs-12 col-sm-12 col-md-2 col-lg-2">
                 <div class="text-align-right">
-                  <button  mat-raised-button color="primary" (click)="openInstallWizard()" *ngIf="gatekeeperConstraintTemplates === null; else recommendationButton">
+                  <button mat-raised-button color="primary" [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" (click)="openInstallWizard()" *ngIf="gatekeeperConstraintTemplates === null; else recommendationButton">
                     Install
                   </button>
                   <ng-template #recommendationButton>
-                    <button  mat-raised-button color="primary" (click)="openAddConstraintDialog()" *ngIf="gatekeeperConstraintTemplates?.length === 0">
+                    <button  mat-raised-button color="primary" [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" (click)="openAddConstraintDialog()" *ngIf="gatekeeperConstraintTemplates?.length === 0">
                       Setup
                     </button>
                   </ng-template>

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-bench/kube-bench.component.html
@@ -51,7 +51,7 @@
               </p>
             </div>
             <div class="col-sm-5 col-xs-5 page-card-title-button-group-right-align">
-              <button mat-raised-button color="primary" (click)="openDialog()">Run Audit</button>
+              <button mat-raised-button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" color="primary" (click)="openDialog()">Run Audit</button>
             </div>
           </div>
           </mat-card-content>
@@ -69,7 +69,7 @@
               </div>
             </div>
             <div class="col-xs-7 run-audit-button">
-              <button mat-raised-button color="primary" (click)="openDialog()">Run Audit</button>
+              <button mat-raised-button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" color="primary" (click)="openDialog()">Run Audit</button>
             </div>
           </mat-card-header>
           <mat-card-content>

--- a/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
+++ b/dash/frontend/src/app/modules/private/pages/cluster/kube-hunter/kube-hunter.component.html
@@ -51,7 +51,7 @@
                 </p>
               </div>
               <div class="col-sm-5 col-xs-5 page-card-title-button-group-right-align">
-                <button mat-raised-button color="primary" (click)="openDialog()">Run Audit</button>
+                <button mat-raised-button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" color="primary" (click)="openDialog()">Run Audit</button>
               </div>
             </div>
           </mat-card-content>
@@ -69,7 +69,7 @@
               </div>
             </div>
             <div class="col-xs-7 run-audit-button">
-              <button mat-raised-button color="primary" (click)="openDialog()">Run Audit</button>
+              <button mat-raised-button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" color="primary" (click)="openDialog()">Run Audit</button>
             </div>
           </mat-card-header>
           <mat-card-content>

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.html
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.html
@@ -2,7 +2,8 @@
   <div class="page-container-content">
     <app-sub-navigation [title]="exception?.title + ' Details'"
                         buttonTitle="Edit" buttonIcon="create"
-                        [button2]="{title: 'Delete', icon: 'delete', color: 'warn'}"
+                        [buttonAllowedRoles]="[Authority.ADMIN, Authority.SUPER_ADMIN]"
+                        [button2]="subnavigationButton2Config"
                         (buttonClicked)="editException()"
                         (button2Clicked)="deleteException()"
     ></app-sub-navigation>

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-details/exception-details.component.ts
@@ -8,9 +8,10 @@ import { CommentService } from '../../../../../core/services/comment.service';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import { JwtAuthService } from '../../../../../core/services/jwt-auth.service';
 import { IComment } from '../../../../../core/entities/IComment';
-import { Observable } from 'rxjs';
 import {AlertDialogComponent} from '../../../../shared/alert-dialog/alert-dialog.component';
 import {take} from 'rxjs/operators';
+import {Authority, AuthorityId} from '../../../../../core/enum/Authority';
+import {ThemePalette} from '@angular/material/core';
 
 @Component({
   selector: 'app-exception-details',
@@ -23,6 +24,15 @@ export class ExceptionDetailsComponent implements OnInit {
   commentForm: FormGroup;
   comments: IComment[];
   isSubmitting = false;
+  subnavigationButton2Config = {
+    title: 'Delete',
+    icon: 'delete',
+    color: 'warn' as ThemePalette,
+    allowedRoles: [Authority.ADMIN, Authority.SUPER_ADMIN]
+  };
+
+  // Make accessible to HTML
+  readonly Authority = Authority;
 
   constructor(
     private router: Router,

--- a/dash/frontend/src/app/modules/private/pages/exceptions/exception-list/exception-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/exceptions/exception-list/exception-list.component.html
@@ -41,9 +41,9 @@
             </mat-cell>
           </ng-container>
 
-          <ng-container matColumnDef="edit" [allowedRoles]="['ADMIN', 'SUPER_ADMIN']">
-            <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
-            <mat-cell *matCellDef="let exception">
+          <ng-container matColumnDef="edit">
+            <mat-header-cell [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" *matHeaderCellDef>Actions</mat-header-cell>
+            <mat-cell [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" *matCellDef="let exception">
               <a mat-icon-button [routerLink]="['/private', 'exceptions', exception?.id, 'edit']">
                 <mat-icon>create</mat-icon>
               </a>

--- a/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/falco/falco-events-list/falco-events-list.component.html
@@ -3,7 +3,7 @@
     <div class="row page-title-button-group-spacing">
       <div class="page-title col-xs-12 col-sm-9">Project Falco</div>
       <div class="col-xs-12 col-sm-3 start-xs end-sm">
-        <button mat-raised-button color="primary" id="installButton" (click)="openDialog()">Install</button>
+        <button mat-raised-button [allowedRoles]="['ADMIN', 'SUPER_ADMIN']" color="primary" id="installButton" (click)="openDialog()">Install</button>
         <button mat-raised-button color="primary"
                 *ngIf="isAllowed"
                 [routerLink]="['/private', 'clusters', this.clusterId, 'falco', 'settings']"

--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
@@ -10,6 +10,7 @@
             <mat-spinner *ngIf="displayImageScanSpinner$ | async" [diameter]="30"></mat-spinner>
           </div>
           <button type="button" color="primary" mat-raised-button
+             [allowedRoles]="['ADMIN', 'SUPER_ADMIN']"
              class=""
              *ngIf="dataSource || !dataSource"
              [disabled]="displayImageScanSpinner$ | async"

--- a/dash/frontend/src/app/modules/private/pages/policies/policy-list/policy-list.component.html
+++ b/dash/frontend/src/app/modules/private/pages/policies/policy-list/policy-list.component.html
@@ -29,8 +29,8 @@
             <mat-cell *matCellDef="let policy">{{policy?.rescanGracePeriod || 'None'}}</mat-cell>
           </ng-container>
           <ng-container matColumnDef="edit">
-            <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
-            <mat-cell *matCellDef="let policy">
+            <mat-header-cell *matHeaderCellDef [allowedRoles]="['ADMIN', 'SUPER_ADMIN']">Actions</mat-header-cell>
+            <mat-cell *matCellDef="let policy" [allowedRoles]="['ADMIN', 'SUPER_ADMIN']">
               <a mat-icon-button [routerLink]="['/private', 'policies', policy?.id, 'edit']">
                 <mat-icon>create</mat-icon>
               </a>

--- a/dash/frontend/src/app/modules/shared/alert-dialog/alert-dialog.component.ts
+++ b/dash/frontend/src/app/modules/shared/alert-dialog/alert-dialog.component.ts
@@ -30,14 +30,15 @@ export class AlertDialogComponent {
             if (!environment.production) {
               console.log(result);
             }
+
+            this.matDialogRef.close(true);
+            if (this.data?.afterRoute?.length > 0) {
+              this.router.navigate(this.data.afterRoute);
+            } else if (this.data?.reload) {
+              window.location.reload();
+            }
           }
         });
-    }
-    this.matDialogRef.close(true);
-    if (this.data?.afterRoute?.length > 0) {
-      this.router.navigate(this.data.afterRoute);
-    } else if (this.data?.reload) {
-      window.location.reload();
     }
   }
 

--- a/dash/frontend/src/app/modules/shared/alert-dialog/alert-dialog.component.ts
+++ b/dash/frontend/src/app/modules/shared/alert-dialog/alert-dialog.component.ts
@@ -31,14 +31,20 @@ export class AlertDialogComponent {
               console.log(result);
             }
 
-            this.matDialogRef.close(true);
-            if (this.data?.afterRoute?.length > 0) {
-              this.router.navigate(this.data.afterRoute);
-            } else if (this.data?.reload) {
-              window.location.reload();
-            }
+            this.submitComplete();
           }
         });
+    } else {
+      this.submitComplete();
+    }
+  }
+
+  submitComplete() {
+    this.matDialogRef.close(true);
+    if (this.data?.afterRoute?.length > 0) {
+      this.router.navigate(this.data.afterRoute);
+    } else if (this.data?.reload) {
+      window.location.reload();
     }
   }
 

--- a/dash/frontend/src/app/modules/shared/side-nav/interfaces/menu-content-trigger.interface.ts
+++ b/dash/frontend/src/app/modules/shared/side-nav/interfaces/menu-content-trigger.interface.ts
@@ -1,7 +1,9 @@
+import {Authority} from '../../../../core/enum/Authority';
+
 export class IMenuContentTrigger {
   name: string;
   title: string;
   icon: string;
-  adminsOnly: boolean;
+  allowedRoles: Authority[];
   callback: (parent) => void;
 }

--- a/dash/frontend/src/app/modules/shared/side-nav/interfaces/menu-content-trigger.interface.ts
+++ b/dash/frontend/src/app/modules/shared/side-nav/interfaces/menu-content-trigger.interface.ts
@@ -2,5 +2,6 @@ export class IMenuContentTrigger {
   name: string;
   title: string;
   icon: string;
+  adminsOnly: boolean;
   callback: (parent) => void;
 }

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
@@ -10,7 +10,7 @@
 
     <mat-nav-list id="main-list">
       <div *ngFor="let contentTrigger of contentTriggerButtons">
-        <mat-list-item (click)="contentTriggerClicked(contentTrigger.name)">
+        <mat-list-item (click)="contentTriggerClicked(contentTrigger.name)" *ngIf="!contentTrigger.adminsOnly || isAdmin">
           <mat-icon title="Add Cluster Group">{{ contentTrigger.icon }}</mat-icon>
           {{ contentTrigger.title }}
         </mat-list-item>

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.html
@@ -10,7 +10,7 @@
 
     <mat-nav-list id="main-list">
       <div *ngFor="let contentTrigger of contentTriggerButtons">
-        <mat-list-item (click)="contentTriggerClicked(contentTrigger.name)" *ngIf="!contentTrigger.adminsOnly || isAdmin">
+        <mat-list-item (click)="contentTriggerClicked(contentTrigger.name)" [allowedRoles]="contentTrigger.allowedRoles">
           <mat-icon title="Add Cluster Group">{{ contentTrigger.icon }}</mat-icon>
           {{ contentTrigger.title }}
         </mat-list-item>

--- a/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.ts
+++ b/dash/frontend/src/app/modules/shared/side-nav/side-nav.component.ts
@@ -1,12 +1,10 @@
-import {AfterViewInit, Component, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
-import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
-import {Observable, Subject} from 'rxjs';
-import {map, shareReplay} from 'rxjs/operators';
+import {AfterViewInit, Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
+import {Observable} from 'rxjs';
 import {Router} from '@angular/router';
 import {IMenuItem} from './interfaces/menu-item.interface';
 import {JwtAuthService} from '../../../core/services/jwt-auth.service';
 import {IMenuContentTrigger} from './interfaces/menu-content-trigger.interface';
-import {Authority, AuthorityValues} from '../../../core/enum/Authority';
+import {AuthorityValues} from '../../../core/enum/Authority';
 import {MatSidenav} from '@angular/material/sidenav';
 
 @Component({

--- a/dash/frontend/src/app/modules/shared/subnavigation/sub-navigation.component.html
+++ b/dash/frontend/src/app/modules/shared/subnavigation/sub-navigation.component.html
@@ -3,11 +3,22 @@
     {{ title }}
   </div>
   <div *ngIf="buttonTitle || buttonUrl || button2" class="col-xs-12 col-sm-6 start-xs end-sm" id="sub-navigation-buttons">
-    <button mat-raised-button color="primary" [routerLink]="buttonUrl" (click)="emitButtonEvent($event)" id="sub-navigation-button-one">
+    <button mat-raised-button color="primary"
+            [allowedRoles]="buttonAllowedRoles || ['READ_ONLY', 'ADMIN', 'SUPER_ADMIN']"
+            [routerLink]="buttonUrl"
+            (click)="emitButtonEvent($event)"
+            id="sub-navigation-button-one"
+    >
       <mat-icon *ngIf="buttonIcon">{{buttonIcon}}</mat-icon>
       {{buttonTitle}}
     </button>
-    <button mat-raised-button *ngIf="button2" [color]="button2.color || 'accent'" [routerLink]="button2.url" (click)="emitButton2Event($event)" id="sub-navigation-button-two">
+    <button mat-raised-button *ngIf="button2"
+            [allowedRoles]="button2?.allowedRoles || ['READ_ONLY', 'ADMIN', 'SUPER_ADMIN']"
+            [color]="button2.color || 'accent'"
+            [routerLink]="button2.url"
+            (click)="emitButton2Event($event)"
+            id="sub-navigation-button-two"
+    >
       <mat-icon *ngIf="button2?.icon">{{button2.icon}}</mat-icon>
       {{button2.title}}
     </button>

--- a/dash/frontend/src/app/modules/shared/subnavigation/sub-navigation.component.ts
+++ b/dash/frontend/src/app/modules/shared/subnavigation/sub-navigation.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {ThemePalette} from '@angular/material/core';
+import {Authority} from '../../../core/enum/Authority';
 
 @Component({
   selector: 'app-sub-navigation',
@@ -9,11 +10,13 @@ import {ThemePalette} from '@angular/material/core';
 export class SubNavigationComponent {
   @Input() buttonTitle: string;
   @Input() buttonUrl: any;
+  @Input() buttonAllowedRoles: Authority[] = [Authority.READ_ONLY, Authority.ADMIN, Authority.SUPER_ADMIN];
   @Input() button2?: {
     title: string,
     url?: any,
     color?: ThemePalette,
     icon?: string,
+    allowedRoles?: Authority[];
   };
   @Input() title: string;
   @Input() buttonIcon: string;


### PR DESCRIPTION
# Changes made from auth audit
- Gatekeeper (All cahnges for RO users)
   - Get Constraint Template endpoint made accessible to RO users
   - Constraint Details page - Edit button becomes 'View' button for viewing the YML of the template, and opened dialog 
is read only
   - Gatekeeper not installed - no longer has install button in recommendation section
   - Gate keeper installed with no constraint templates - no longer has add button in recommendations section
- Reports - All endpoints made accessible to RO users
- 'Add Cluster Group' button in side nav no longer visible for RO users
- kube-bench - no longer has 'run audit button' for RO users
- kube-hunter - no longer has 'run audit button' for RO users
- Exceptions Details - edit & delete button no longer visible for RO users
- exceptions list - action column no longer visible to RO users
- Falco - Install button no longer visible for RO users
- Image scan results - (re)-scan button no longer visible for RO users
- policy list - actiosn no longer visible for RO users

# Misc changes made
- Gave color to submit button on reset password form
- Gatekeeper constraint template details - After saving edits to the constraint template, the table of constraints would get cleared. Now that does not happen
- Fixed race condition in AlertDialogComponent that could cause the page to navigate before the web request completed. This result in behaviors such as deleting a cluster, and the redirect to the cluster group page would happen before the cluster was deleted - resulting in the deleted cluster still being shown on that page.