### PR TITLE
Add ability to specify extra annotations and labels for dash and trawler

### DIFF
--- a/manifests/charts/dash/templates/deployment.yaml
+++ b/manifests/charts/dash/templates/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "dash.fullname" . }}
   labels:
     {{- include "dash.labels" . | nindent 4 }}
+{{- if .Values.extraDeploymentLabels }}
+    {{- .Values.extraDeploymentLabels | toYaml | nindent 4 }}
+{{- end }}
+{{- if .Values.extraDeploymentAnnotations }}
+  annotations:
+    {{- .Values.extraDeploymentAnnotations | toYaml | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -22,8 +29,14 @@ spec:
         checksum/{{ include "dash.fullname" . }}-secrets-extra: {{ include (print $.Template.BasePath "/secret-extra.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
+{{- if .Values.extraPodAnnotations }}
+        {{- .Values.extraPodAnnotations | toYaml | nindent 8 }}
+{{- end }}
       labels:
         {{- include "dash.selectorLabels" . | nindent 8 }}
+{{- if .Values.extraPodLabels }}
+        {{- .Values.extraPodLabels | toYaml | nindent 8 }}
+{{- end }}
     spec:
       serviceAccount: dash-sa
       initContainers:

--- a/manifests/charts/trawler/templates/deployment.yaml
+++ b/manifests/charts/trawler/templates/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "trawler.fullname" . }}
   labels:
     {{- include "trawler.labels" . | nindent 4 }}
+{{- if .Values.extraDeploymentLabels }}
+    {{- .Values.extraDeploymentLabels | toYaml | nindent 4 }}
+{{- end }}
+{{- if .Values.extraDeploymentAnnotations }}
+  annotations:
+    {{- .Values.extraDeploymentAnnotations | toYaml | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -22,8 +29,14 @@ spec:
         checksum/{{ include "trawler.fullname" . }}-secrets-extra: {{ include (print $.Template.BasePath "/secret-extra.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
+{{- if .Values.extraPodAnnotations }}
+        {{- .Values.extraPodAnnotations | toYaml | nindent 8 }}
+{{- end }}
       labels:
         {{- include "trawler.selectorLabels" . | nindent 8 }}
+{{- if .Values.extraPodLabels }}
+        {{- .Values.extraPodLabels | toYaml | nindent 8 }}
+{{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
There may be certain instances where someone may need to apply specific labels or annotations to the pod or deployment for m9sweeper's dash or trawler. This commit adds that ability to the helm charts.