### PR TITLE
Update aws eks benchmarking to `eks-1.2.0` for kube-bench chart

### DIFF
--- a/manifests/charts/kube-bench/templates/cronjob-eks.yaml
+++ b/manifests/charts/kube-bench/templates/cronjob-eks.yaml
@@ -59,7 +59,7 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: [ "/bin/sh" ]
-              args: [ "-c", "kube-bench run --targets node --benchmark eks-1.0 --json > kube-bench-results.json && wget -S -O - --header \"Content-Type: application/json\" --post-file kube-bench-results.json \"{{ .Values.reportsurl }}\"" ]
+              args: [ "-c", "kube-bench run --targets node --benchmark eks-1.2.0 --json > kube-bench-results.json && wget -S -O - --header \"Content-Type: application/json\" --post-file kube-bench-results.json \"{{ .Values.reportsurl }}\"" ]
                 {{- with .Values.customArguments }}
 {{ toYaml . | indent 16 }}
                 {{- end }}


### PR DESCRIPTION
As per CIS Kubernetes Benchmark support for EKS is as below.

https://github.com/aquasecurity/kube-bench/blob/main/docs/platforms.md#cis-kubernetes-benchmark-support

`eks-1` is not valid anymore results in below error, `eks-1.2.0` should fix the issue.

```
error validating targets: No targets configured for eks-1.0
```