### PR TITLE
DB migrate job to fix race condition.

### DIFF
--- a/dash/backend/package.json
+++ b/dash/backend/package.json
@@ -33,9 +33,10 @@
     "cli:users:init": "node ${CLI_PATH:=./dist/src/cli.js} users:init",
     "cli:populate:kubernetes-history": "node ${CLI_PATH:=./dist/src/cli.js} populate:kubernetes-history",
     "cli:cluster:seed": "node ${CLI_PATH:=./dist/src/cli.js} cluster:seed",
-    "cli:init:all": "npm run cli:users:init && npm run cli:cluster:seed && npm run cli:registries:init && npm run cli:exceptions:init && npm run cli:cluster:sync-all",
+    "cli:init:all": "npm run cli:database:migrate && npm run cli:users:init && npm run cli:cluster:seed && npm run cli:registries:init && npm run cli:exceptions:init && npm run cli:cluster:sync-all",
     "cli:database:check": "node ${CLI_PATH:=./dist/src/cli.js} database:check",
-    "cli:database:wait": "node ${CLI_PATH:=./dist/src/cli.js} database:wait"
+    "cli:database:wait": "node ${CLI_PATH:=./dist/src/cli.js} database:wait",
+    "cli:database:migrate": "node ${CLI_PATH:=./dist/src/cli.js} database:migrate"
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.18.1",

--- a/dash/backend/src/modules/command-line/command-line.module.ts
+++ b/dash/backend/src/modules/command-line/command-line.module.ts
@@ -13,7 +13,7 @@ import { JobsCliController } from './controllers/jobs-cli.controller';
 import { CronJobsController } from './controllers/cron-jobs.controller';
 import { CliCommandBuilderService } from './services/cli-command-builder.service';
 import { ScheduleModule } from '@nestjs/schedule';
-import { DatabaseStatusCommand } from './commands/database-status.command';
+import { DatabaseCommand } from './commands/database-command.service';
 
 @Global()
 @Module({
@@ -30,7 +30,7 @@ import { DatabaseStatusCommand } from './commands/database-status.command';
         GatekeeperExceptionCommand,
         SyncExceptionStatusCommand,
         ImageRescanningService,
-        DatabaseStatusCommand,
+        DatabaseCommand,
         CliCommandBuilderService
     ],
     imports: [

--- a/dash/backend/src/modules/command-line/enums/cli-commands.ts
+++ b/dash/backend/src/modules/command-line/enums/cli-commands.ts
@@ -9,4 +9,5 @@ export enum CliCommands {
   PopulateKubernetesHistory = 'populate:kubernetes-history',
   DatabaseCheck = 'database:check',
   DatabaseWait = 'database:wait',
+  DatabaseMigrate = 'database:migrate',
 }

--- a/dash/backend/src/modules/command-line/services/cli-command-builder.service.ts
+++ b/dash/backend/src/modules/command-line/services/cli-command-builder.service.ts
@@ -99,7 +99,7 @@ export class CliCommandBuilderService {
             ),
             new CliCommand(
               CliCommands.DatabaseMigrate,
-              'Runs database migrations if they are enabled.',
+              'Runs database migrations.',
               () => this.databaseCommand.runMigrations()
             )
         ];

--- a/dash/backend/src/modules/command-line/services/cli-command-builder.service.ts
+++ b/dash/backend/src/modules/command-line/services/cli-command-builder.service.ts
@@ -7,7 +7,7 @@ import { GatekeeperExceptionCommand } from '../commands/gatekeeper-exception.com
 import { KubernetesHistoryCommand } from '../commands/kubernetes-history.command';
 import { ClusterCommand } from '../commands/cluster.command';
 import { SyncExceptionStatusCommand } from '../commands/exception.command';
-import { DatabaseStatusCommand } from "../commands/database-status.command";
+import { DatabaseCommand } from "../commands/database-command.service";
 
 
 @Injectable()
@@ -21,7 +21,7 @@ export class CliCommandBuilderService {
       protected readonly kubernetesHistoryCommand: KubernetesHistoryCommand,
       protected readonly clusterCommand: ClusterCommand,
       protected readonly exceptionCommand: SyncExceptionStatusCommand,
-      protected readonly databaseStatusCommand: DatabaseStatusCommand
+      protected readonly databaseCommand: DatabaseCommand
     ) {}
 
     get commands(): CliCommand[] {
@@ -90,13 +90,18 @@ export class CliCommandBuilderService {
             new CliCommand(
                 CliCommands.DatabaseCheck,
                 'Runs a one-time check against the database to see if it is available and responding to queries',
-                () => this.databaseStatusCommand.runCheck(),
+                () => this.databaseCommand.runCheck(),
             ),
             new CliCommand(
                 CliCommands.DatabaseWait,
                 'Waits for the database to be available and responding to queries',
-                () => this.databaseStatusCommand.waitForDatabse(),
+                () => this.databaseCommand.waitForDatabase(),
             ),
+            new CliCommand(
+              CliCommands.DatabaseMigrate,
+              'Runs database migrations if they are enabled.',
+              () => this.databaseCommand.runMigrations()
+            )
         ];
     }
 }


### PR DESCRIPTION
- Add new database:migrate cli command that runs migrations.
- Added as first job in init:all command chain to ensure DB migrations are run before they other jobs run.
- Renamed DatabaseStatusCommand to DatabaseCommand so that it could more logicallyinclude this new functionality
  - Fixed typo in function name:  'waitForDatabse' > 'waitForDatabase'