### PR TITLE
revert to include container image registry

### DIFF
--- a/dash/backend/src/modules/falco/service/falco.service.ts
+++ b/dash/backend/src/modules/falco/service/falco.service.ts
@@ -122,7 +122,8 @@ export class FalcoService {
         falcoLog.clusterId = clusterId;
         falcoLog.rule = falcoWebhookLog.rule;
         falcoLog.namespace = falcoWebhookLog.outputFields.k8sNamespaceName;
-        falcoLog.image = falcoWebhookLog.outputFields.containerImage;
+        // With the Falco settings configured, this is the ony field we get for the image
+        falcoLog.image = falcoWebhookLog.outputFields.containerImageRepository;
         falcoLog.container = falcoWebhookLog.outputFields.k8sPodName;
         falcoLog.level = falcoWebhookLog.priority;
         falcoLog.message = falcoWebhookLog.output;


### PR DESCRIPTION
- This was changed to use containerImage mid-July, which Falco is not sending currently.
- This reverts it to the previous state where we use containerImageRegistry instead.