### PR TITLE
can now scan images that are marked as scan_queued

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
+++ b/dash/frontend/src/app/modules/private/pages/image/image-scan-result/image-scan-result.component.html
@@ -9,10 +9,10 @@
           <div class="me-lg-3 me-xs-0">
             <mat-spinner *ngIf="displayImageScanSpinner$ | async" [diameter]="30"></mat-spinner>
           </div>
+          <!-- This button should not be disabled, as it allows re-queueing image scans where image scans get "stuck"-->
           <button type="button" color="primary" mat-raised-button
              [allowedRoles]="['ADMIN', 'SUPER_ADMIN']"
              *ngIf="dataSource || !dataSource"
-             [disabled]="displayImageScanSpinner$ | async"
              (click)="scanImage()">{{ scanButtonText }}</button>
         </div>
       </div>


### PR DESCRIPTION
Revert to original behavior where you can trigger scans of images that are already scanned.

This allows users to trigger new scans of images that get "stuck" if something happens in the scanning flow and nothing gets sent back to dash