### PR TITLE
Update docs

### DIFF
--- a/docs/content/en/docs/Concepts/Image Scanning/Enforcing Compliance/installing-webhook.md
+++ b/docs/content/en/docs/Concepts/Image Scanning/Enforcing Compliance/installing-webhook.md
@@ -9,6 +9,11 @@ description: >
 In order to have m9sweeper enforce image scanning compliance in your cluster, you need to install a validating webhook
 in your cluster. This should be done automatically by m9sweeper during the setup process, but if for some reason it
 was not you can click "Update Kubeconfig" on your cluster's settings page and run through the setup wizard again
-to have it install the webhook for you. 
+to have it install the webhook for you.
 
 ![../img_1.png](../img_1.png)
+
+{{% alert title="Note on the Webhook" color="primary" %}}
+If you are installing this on Azure Kubernetes Services (AKS) or Google Kubernetes Engine (GKE) or any other installation where the kubernetes API is blocked from reaching
+out to external URL for things such as Validating Webhooks, please see the section reguarding Validating Webhook installations in the [advanced installation guide](../advanced-install).
+{{% /alert %}}

--- a/docs/content/en/docs/Concepts/Image Scanning/scanning-in-cicd-pipelines.md
+++ b/docs/content/en/docs/Concepts/Image Scanning/scanning-in-cicd-pipelines.md
@@ -3,19 +3,19 @@ title: "Scanning in CICD Pipelines"
 linkTitle: "Scanning in CICD Pipelines"
 weight: 4
 description: >
-  Learn how to give developers feedback in your CICD pipelines. 
+  Learn how to give developers feedback in your CICD pipelines.
 ---
 
-You can automatically scan images using trawler in your automated CICD pipelines. The easiest way to do this is by 
-running trawler from the command line using the container image. It will look something like this. 
+You can automatically scan images using trawler in your automated CICD pipelines. The easiest way to do this is by
+running trawler from the command line using the container image. It will look something like this.
 
     docker run \
         --env "M9SWEEPER_URL=XXX" \
         --env "M9SWEEPER_API_KEY=XXX" \
         --env "CLUSTER_NAME=XXX" \
         --env "DOCKER_IMAGE_URL=XXX" \
-        -it m9sweeper/trawler trawler scan
+        -it ghcr.io/m9sweeper/trawler trawler scan
 
-Note that you will need to provide an API key as well as the name of the cluster you are scanning it for 
+Note that you will need to provide an API key as well as the name of the cluster you are scanning it for
 so that it can authenticate with m9sweeper. You will have to run a scan for each cluster you plan to deploy it to because
-each cluster might have different policies setup. 
+each cluster might have different policies setup.


### PR DESCRIPTION
Adds a notice about using the webhook proxy and fixes the trawler docker image URL shown in the example command for running trawler in a pipeline.