### PR TITLE
UI fixes

### DIFF
--- a/dash/frontend/src/app/modules/private/pages/cluster/cluster-info/cluster-info.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/cluster/cluster-info/cluster-info.component.ts
@@ -67,6 +67,7 @@ export class ClusterInfoComponent implements OnInit, OnDestroy {
         this.isClusterLoaded = true;
         this.cluster = response.data;
         this.isEnforcementEnabled = this.cluster.isEnforcementEnabled;
+        this.isImageScanningEnforcementEnabled = this.cluster.isImageScanningEnforcementEnabled;
 
         this.infoService.getDatabaseStatus().pipe(take(1)).subscribe(res => {
           this.m9ver = res.data.git_tag;

--- a/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
+++ b/dash/frontend/src/app/modules/private/pages/external-auth-configuration/external-auth-configuration-create/external-auth-configuration-create.component.html
@@ -11,7 +11,7 @@
       </mat-form-field>
     </div>
   </div>
-  <div *ngIf="!oauthAuthActivated">
+  <div class="row" *ngIf="!oauthAuthActivated">
     <div class="col-xs-12">
       <mat-form-field>
         <mat-label>Provider Type</mat-label>


### PR DESCRIPTION
This fixes some small UI issues I found:

- The Image Scanning Enforcement toggle was not loading the value from the database to set it properly. This means a user could enable it, and it would be enabled in the database but the user could not disable it.
- The Provider Type field on the Add Sign On Method pop-up was offset to the left compared to everything else when the Auth Type field was not selected or was set to LDAP.