### PR TITLE
Fix Selenium race condition

### DIFF
--- a/selenium-testing/test/specs/cluster/images.spec.ts
+++ b/selenium-testing/test/specs/cluster/images.spec.ts
@@ -121,6 +121,8 @@ describe('Images Page::', () => {
     // Download the Issues list
     it('5 Download the Issues list', async () => {
         // Locate the download link
+        await $("//mat-icon[contains(normalize-space(), 'download')]/parent::button/span[contains(@class, 'mat-mdc-button-touch-target')]")
+          .waitForExist({timeout: 30000, interval: 1000, timeoutMsg: "Issues list download button should be present"});
         const downloadButton = await $("//mat-icon[contains(normalize-space(), 'download')]/parent::button/span[contains(@class, 'mat-mdc-button-touch-target')]");
         expect(downloadButton).toBePresent(
             {message: "Issues list download button should be present"}


### PR DESCRIPTION
Added a waitForExist call before trying to use the download button.

This causes Selenium to try to find the button once every second. Once it finds the button, it will continue. If it goes 30s without finding the button, it will fail the test.