### PR TITLE
Kube hunter section can now be used for security audit reports

### DIFF
--- a/dash/backend/src/modules/kube-hunter/dto/kube-hunter-raw.interface.ts
+++ b/dash/backend/src/modules/kube-hunter/dto/kube-hunter-raw.interface.ts
@@ -32,7 +32,7 @@ interface IKHRawResponseServices {
   options: IKHRawResponseOptions
 }
 
-interface IKHRawResponseVulnerabilities {
+export interface IKHRawResponseVulnerabilities {
   value: IKHRawResponseVulnerability[]
   key: string
   obj: IKHRawResponseObjDefinition
@@ -58,7 +58,7 @@ interface IKHRawResponseService {
   location: string
 }
 
-interface IKHRawResponseVulnerability {
+export interface IKHRawResponseVulnerability {
   location: string
   vid: string
   category: string

--- a/dash/backend/src/modules/kube-hunter/service/kube-hunter.service.ts
+++ b/dash/backend/src/modules/kube-hunter/service/kube-hunter.service.ts
@@ -25,6 +25,11 @@ export class KubeHunterService {
         return this.kubeHunterDao.getRecentKubeHunterReportForCluster(clusterId, minDate);
     }
 
+    async getMostRecentReportForCluster(clusterId: number): Promise<KubeHunterDto> {
+        return this.kubeHunterDao.getAllReportsForCluster(clusterId, 0, 1)
+          .then(r => r[0]);
+    }
+
     async getAllReportsForCluster(clusterId: number,
                                   page  = 0,
                                   limit  = 10):

--- a/dash/backend/src/modules/security-audit-report/enums/security-audit-report-tools.ts
+++ b/dash/backend/src/modules/security-audit-report/enums/security-audit-report-tools.ts
@@ -5,5 +5,7 @@
  */
 export enum SecurityAuditReportTools {
   TRIVY = 'trivy',
-  KUBESEC = 'kubesec'
+  KUBESEC = 'kubesec',
+  KUBEHUNTER = 'kubehunter'
+
 }

--- a/dash/backend/src/modules/security-audit-report/security-audit.module.ts
+++ b/dash/backend/src/modules/security-audit-report/security-audit.module.ts
@@ -5,6 +5,7 @@ import {SecurityAuditTrivyService} from './services/security-audit-trivy.service
 import {SecurityAuditClusterService} from './services/security-audit-cluster.service';
 import {SecurityAuditToolServiceFactory} from './services/security-audit-tool-service.factory';
 import {SecurityAuditKubesecService} from './services/security-audit-kubesec.service';
+import {SecurityAuditKubehunterService} from './services/security-audit-kubehunter.service';
 
 @Global()
 @Module({
@@ -15,6 +16,7 @@ import {SecurityAuditKubesecService} from './services/security-audit-kubesec.ser
     SecurityAuditTrivyService,
     SecurityAuditToolServiceFactory,
     SecurityAuditKubesecService,
+    SecurityAuditKubehunterService,
   ],
   exports: [
     SecurityAuditReportService,
@@ -23,6 +25,7 @@ import {SecurityAuditKubesecService} from './services/security-audit-kubesec.ser
     SecurityAuditTrivyService,
     SecurityAuditToolServiceFactory,
     SecurityAuditKubesecService,
+    SecurityAuditKubehunterService,
   ],
   controllers: []
 })

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kubehunter.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kubehunter.service.ts
@@ -1,0 +1,138 @@
+import {Injectable} from '@nestjs/common';
+import {Content, ContentTable, TableCell} from 'pdfmake/interfaces';
+import {SecurityAuditReportPdfHelpersService} from './security-audit-report-pdf-helpers.service';
+import {IAuditReportSectionService} from '../interfaces/IAuditReportSectionService';
+import {ClusterObjectSummary} from '../../cluster/dto/cluster-object-summary';
+import {KubeHunterService} from '../../kube-hunter/service/kube-hunter.service';
+import {
+  IKHRawResponseVulnerability,
+  IKubeHunterRawVulnerabilities
+} from '../../kube-hunter/dto/kube-hunter-raw.interface';
+import {format} from 'date-fns';
+
+@Injectable()
+export class SecurityAuditKubehunterService implements IAuditReportSectionService {
+
+  constructor(
+    protected readonly pdfHelpers: SecurityAuditReportPdfHelpersService,
+    protected readonly kubeHunterService: KubeHunterService,
+  ) {
+
+  }
+
+
+  async buildClusterContent(cluster: ClusterObjectSummary): Promise<{ content: Content; summaryRow: TableCell[] }> {
+    const report = await this.kubeHunterService.getMostRecentReportForCluster(cluster.id);
+    const locations: Record<string, IKHRawResponseVulnerability[]>  = {}
+    let content: Content;
+    let summaryRow: TableCell[];
+    if (report) {
+      let totalHigh = 0;
+      let totalMed = 0;
+      let totalLow = 0;
+      const processed = (JSON.parse(report?.vulnerabilities) as IKubeHunterRawVulnerabilities)?.value?.value;
+      for (const vuln of processed) {
+        if (locations[vuln.location]) {
+          locations[vuln.location].push(vuln);
+        } else {
+          locations[vuln.location] = [vuln];
+        }
+
+        if (vuln.severity === 'high') {
+          totalHigh++;
+        } else if (vuln.severity === 'medium') {
+          totalMed++;
+        } else {
+          totalLow++;
+        }
+      }
+      content = this.buildKubeHunterLocationTables(locations);
+      summaryRow = [cluster.name, format(new Date(+report.createdAt), 'PPP'), totalHigh, totalMed, totalLow];
+    } else {
+      content = { text: 'kube-hunter scan not run', style: 'italics'};
+      summaryRow = [cluster.name, 'N/A', {text: 'No scan run', style: 'italics', colSpan: 3 },{},{}];
+    }
+
+
+    return {
+      summaryRow,
+      content: [this.buildClusterKubehunterIntro(), content]
+    };
+  }
+
+  buildSummaryContent(summaries: TableCell[][]): Content {
+    const table: ContentTable = {
+      marginBottom: 10,
+      style: 'body',
+      table: {
+        headerRows: 1,
+        widths: ['*', 'auto', 'auto', 'auto', 'auto'],
+        body: [
+          ['Cluster', 'Last Scanned', 'High', 'Medium', 'Low'],
+          ...summaries
+        ]
+      },
+      layout: this.pdfHelpers.coloredTableHeaderLayout()
+    }
+
+    return [
+      this.pdfHelpers.buildSubHeader('Penetration Test with kube-hunter'),
+      {
+        style: 'body',
+        text: [
+          'Kube-hunter runs a non-invasive penetration test in your cluster. ',
+          'It runs as an application in your cluster and then attempts to see whether it can access any sensitive cluster data ',
+          'or whether it has too many privileges. This is similar to what a hacker would do, ',
+          'and informs you whether there are any obvious configuration issues you should try to fix.'
+        ]
+      },
+      table
+    ];
+  }
+
+  /** Builds the cluster specific section of a kube-hunter report */
+  buildClusterKubehunterIntro(): Content[] {
+    return [
+      this.pdfHelpers.buildSubHeader('Penetration Test with kube-hunter'),
+      {
+        style: 'body',
+        text: [
+          'Kube-hunter runs a non-invasive penetration test in your cluster. ',
+          'It runs as an application in your cluster and then attempts to see if it can access any sensitive cluster data or has too many privileges. ',
+          'This is similar to what a hacker would do, and informs you whether there are any obvious configuration issues you should try to fix.',
+        ]
+      },
+    ];
+  }
+
+  buildKubeHunterLocationTables(locationData: Record<string, IKHRawResponseVulnerability[]>): Content[] {
+    const locations = Object.keys(locationData);
+    if (locations.length) {
+      const locationTables: Content[] = [];
+      for (const location of locations) {
+        const rows = locationData[location]
+          .map(v => (
+            [v.severity, v.category, v.vulnerability,
+            v.description, { text: v.avd_reference, link: v.avd_reference, style: 'link' }
+          ]));
+        const table: ContentTable = {
+          marginBottom: 10,
+          style: 'body',
+          table: {
+            headerRows: 1,
+            widths: ['*', 'auto', 'auto', 'auto', 'auto'],
+            body: [
+              ['Severity', 'Category', 'Vulnerability', 'Description', 'Additional Information'],
+              ...rows
+            ]
+          },
+          layout: this.pdfHelpers.coloredTableHeaderLayout()
+        }
+        locationTables.push([{text: `Location: ${location}`, style: 'tableLabel' }, table]);
+      }
+      return locationTables;
+    } else {
+      return [{ text: 'No vulnerabilities found', style: 'italics'}];
+    }
+  }
+}

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
@@ -83,6 +83,9 @@ export class SecurityAuditReportPdfHelpersService {
       },
       bold: {
         bold: true
+      },
+      link: {
+        color: '#0000EE'
       }
     };
   }

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-tool-service.factory.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-tool-service.factory.ts
@@ -3,12 +3,14 @@ import {IAuditReportSectionService} from '../interfaces/IAuditReportSectionServi
 import {SecurityAuditTrivyService} from './security-audit-trivy.service';
 import {SecurityAuditReportTools} from '../enums/security-audit-report-tools';
 import {SecurityAuditKubesecService} from './security-audit-kubesec.service';
+import {SecurityAuditKubehunterService} from './security-audit-kubehunter.service';
 
 @Injectable()
 export class SecurityAuditToolServiceFactory {
   constructor(
     protected readonly trivyToolService: SecurityAuditTrivyService,
-    protected readonly kubesecToolService: SecurityAuditKubesecService
+    protected readonly kubesecToolService: SecurityAuditKubesecService,
+    protected readonly kubehunterToolService: SecurityAuditKubehunterService,
   ) {}
 
   getTool(tool: SecurityAuditReportTools): IAuditReportSectionService {
@@ -17,6 +19,8 @@ export class SecurityAuditToolServiceFactory {
         return this.trivyToolService;
       case SecurityAuditReportTools.KUBESEC:
         return this.kubesecToolService;
+      case SecurityAuditReportTools.KUBEHUNTER:
+        return this.kubehunterToolService;
     }
   }
 

--- a/dash/frontend/src/app/core/enum/SecurityAuditReportTools.ts
+++ b/dash/frontend/src/app/core/enum/SecurityAuditReportTools.ts
@@ -5,5 +5,6 @@
  */
 export enum SecurityAuditReportTools {
   TRIVY = 'trivy',
-  KUBESEC = 'kubesec'
+  KUBESEC = 'kubesec',
+  KUBEHUNTER = 'kubehunter'
 }

--- a/dash/frontend/src/app/modules/private/pages/reports/security-audit-report/security-audit-report.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/reports/security-audit-report/security-audit-report.component.ts
@@ -34,6 +34,10 @@ export class SecurityAuditReportComponent implements OnInit {
     {
       displayName: 'Kubesec',
       value: SecurityAuditReportTools.KUBESEC
+    },
+    {
+      displayName: 'kube-hunter',
+      value: SecurityAuditReportTools.KUBEHUNTER
     }
   ];
 


### PR DESCRIPTION
Ticket: 6991
Added kube-hunter as an option for a tool in the Security Audit reports

# Summary section
Has the intro paragraph, and a summary table with this data for each cluster 
- cluster name
- last scanned (N/A if never scanned)
- High*
- Medium*
- Low*
 *merged into single cell saying 'no scan run' if no scan has been run

# Cluster details section
Has the intro paragraph. If kube-hunter has not been run, or had no vulnerabilities, will display an appropriate message.
Otherwise, for each location with at leasst 1 vulnerability it will display a table with this information: (Largely based on the kube hunter reports detail screen from the UI)
- Severity
- Category
- Vulnerability
- Description
- Additional Information (link to avd.aquasec.com page for the vulnerability, should be clickable link if your pdf viewer supports that)
