### PR TITLE
Security audit kube bench report

### DIFF
--- a/dash/backend/src/modules/kube-bench/dto/kube-bench-dto.ts
+++ b/dash/backend/src/modules/kube-bench/dto/kube-bench-dto.ts
@@ -3,49 +3,47 @@ import { IsJSON, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class KubeBenchLogDto {
     @IsJSON()
-    kubeBenchLog: {
-        Controls: {
-            id: string,
-            version: string,
-            detected_version: string,
-            text: string,
-            node_type: string,
-            tests: {
-                section: string,
+    Controls: {
+        id: string,
+        version: string,
+        detected_version: string,
+        text: string,
+        node_type: string,
+        tests: {
+            section: string,
+            type: string,
+            pass: number,
+            fail: number,
+            warn: number,
+            info: number,
+            desc: string,
+            results: {
+                test_number: string,
+                test_desc: string,
+                audit: string,
+                AuditEnv: string,
+                AuditConfig: string,
                 type: string,
-                pass: number,
-                fail: number,
-                warn: number,
-                info: number,
-                desc: string,
-                results: {
-                    test_number: string,
-                    test_desc: string,
-                    audit: string,
-                    AuditEnv: string,
-                    AuditConfig: string,
-                    type: string,
-                    remediation: string,
-                    test_info: string[],
-                    status: string,
-                    actual_value: string,
-                    scored: boolean,
-                    isMultiple: boolean,
-                    expected_result: string,
-                }[]
-            }[],
-            total_pass: number,
-            total_fail: number,
-            total_warn: number,
-            total_info: number,
+                remediation: string,
+                test_info: string[],
+                status: string,
+                actual_value: string,
+                scored: boolean,
+                isMultiple: boolean,
+                expected_result: string,
+            }[]
         }[],
-        Totals: {
-            total_pass: number,
-            total_fail: number,
-            total_warn: number,
-            total_info: number,
-        }
-    }
+        total_pass: number,
+        total_fail: number,
+        total_warn: number,
+        total_info: number,
+    }[];
+    Totals: {
+        total_pass: number,
+        total_fail: number,
+        total_warn: number,
+        total_info: number,
+    };
 }
 
 // this will have either Totals or just the raw values

--- a/dash/backend/src/modules/security-audit-report/enums/security-audit-report-tools.ts
+++ b/dash/backend/src/modules/security-audit-report/enums/security-audit-report-tools.ts
@@ -6,6 +6,6 @@
 export enum SecurityAuditReportTools {
   TRIVY = 'trivy',
   KUBESEC = 'kubesec',
-  KUBEHUNTER = 'kubehunter'
-
+  KUBEHUNTER = 'kubehunter',
+  KUBEBENCH = 'kubebench',
 }

--- a/dash/backend/src/modules/security-audit-report/security-audit.module.ts
+++ b/dash/backend/src/modules/security-audit-report/security-audit.module.ts
@@ -6,6 +6,7 @@ import {SecurityAuditClusterService} from './services/security-audit-cluster.ser
 import {SecurityAuditToolServiceFactory} from './services/security-audit-tool-service.factory';
 import {SecurityAuditKubesecService} from './services/security-audit-kubesec.service';
 import {SecurityAuditKubehunterService} from './services/security-audit-kubehunter.service';
+import {SecurityAuditKubeBenchService} from './services/security-audit-kube-bench.service';
 
 @Global()
 @Module({
@@ -17,6 +18,7 @@ import {SecurityAuditKubehunterService} from './services/security-audit-kubehunt
     SecurityAuditToolServiceFactory,
     SecurityAuditKubesecService,
     SecurityAuditKubehunterService,
+    SecurityAuditKubeBenchService,
   ],
   exports: [
     SecurityAuditReportService,
@@ -26,6 +28,7 @@ import {SecurityAuditKubehunterService} from './services/security-audit-kubehunt
     SecurityAuditToolServiceFactory,
     SecurityAuditKubesecService,
     SecurityAuditKubehunterService,
+    SecurityAuditKubeBenchService,
   ],
   controllers: []
 })

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
@@ -1,0 +1,66 @@
+import {Injectable} from '@nestjs/common';
+import {Content, ContentTable, TableCell} from 'pdfmake/interfaces';
+import {SecurityAuditReportPdfHelpersService} from './security-audit-report-pdf-helpers.service';
+import {IAuditReportSectionService} from '../interfaces/IAuditReportSectionService';
+import {ClusterObjectSummary} from '../../cluster/dto/cluster-object-summary';
+import {KubeBenchService} from '../../kube-bench/services/kube-bench.service';
+
+@Injectable()
+export class SecurityAuditKubeBenchService implements IAuditReportSectionService {
+
+  constructor(
+    protected readonly pdfHelpers: SecurityAuditReportPdfHelpersService,
+    protected readonly kubebenchService: KubeBenchService,
+  ) {
+
+  }
+
+  async buildClusterContent(cluster: ClusterObjectSummary): Promise<{ content: Content; summaryRow: TableCell[] }> {
+      const kbReport = await this.kubebenchService.getLastBenchReportSummary(cluster.id)
+        .then(r => r?.length ? r[0] : undefined);
+
+
+
+    const summaryRow = [
+      cluster.name,
+      kbReport?.resultsSummary?.total_pass ?? 'N/A',
+      kbReport?.resultsSummary?.total_fail ?? 'N/A',
+      kbReport?.resultsSummary?.total_warn ?? 'N/A',
+    ];
+
+    return { summaryRow, content: []};
+  }
+
+  buildSummaryContent(summaries: TableCell[][]): Content {
+    const table: ContentTable = {
+      marginBottom: 10,
+      style: 'body',
+      table: {
+        headerRows: 1,
+        widths: ['*', 'auto', 'auto', 'auto'],
+        body: [
+          ['Cluster', 'Passed', 'Failed', 'Warnings'],
+          ...summaries
+        ]
+      },
+      layout: this.pdfHelpers.coloredTableHeaderLayout()
+    };
+
+    return [
+      this.pdfHelpers.buildSubHeader('Security Benchmarks with kube-bench'),
+      {
+        style: 'body',
+        text: [
+          'Kube-Bench compares your cluster’s configuration against the Center for Internet Security’s ',
+          'best practices for running a Kubernetes Cluster. It runs as an application with elevated privileges in your cluster ',
+          'and then attempts to see whether the cluster is configured securely.',
+        ]
+      },
+      table
+    ];
+  }
+
+
+
+
+}

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
@@ -123,6 +123,7 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
       }
     } else {
       scannedMessage = 'Unscanned';
+      body.push({ text: 'kube-bench scan not run', style: 'italics', marginBottom: 10 });
     }
 
     const content = [

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
@@ -20,8 +20,6 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
       const kbReport = await this.kubebenchService.getLastBenchReportSummary(cluster.id)
         .then(r => r?.length ? r[0] : undefined);
 
-
-
     const summaryRow = [
       cluster.name,
       kbReport?.resultsSummary?.total_pass ?? 'N/A',
@@ -32,7 +30,7 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
     return {
       summaryRow,
       content: [
-        this.buildClusterIntro(kbReport)
+        this.buildClusterSection(kbReport)
       ]
     };
   }
@@ -66,23 +64,66 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
     ];
   }
 
-  buildClusterIntro(report: KubeBenchDto) {
-
+  buildClusterSection(report: KubeBenchDto) {
     const body = [];
     let scannedMessage = '';
+
     if (report?.resultsJson) {
       const results = report.resultsJson; // convenience
       const total = results.Totals.total_pass + results.Totals.total_fail + results.Totals.total_warn;
       scannedMessage = `${results.Totals.total_pass}/${total} Tests Passed`;
 
+      // Outer loop over the high level sections (ex: 3. Worker Node Security Configuration), and appears in Table of Contents
       for (const section of results.Controls) {
-        body.push(this.pdfHelpers.buildSubHeader(`${section.text} (${section.version} v${section.detected_version})`, { level: 2, style: 'h3' } ));
-      }
+        body.push(this.pdfHelpers.buildSubHeader(`${section.id}. ${section.text} (${section.version} v${section.detected_version})`, { level: 2, style: ['h3', 'bold'] } ));
 
+        // Inner loop over the tests (ex: 3.2. Kubelet) in the section, creating a table for each.
+        for (const test of section.tests) {
+          // Create a table row for each of the individual items tested in this test.
+          const rows = test.results
+            .map(res => {
+              const statusCell: Content = { text: res.status };
+              switch (res.status) {
+                case 'FAIL':
+                  statusCell.style = 'redText';
+                  break;
+                case 'WARN':
+                  statusCell.style = 'goldText';
+                  break;
+              }
+              return [
+                res.test_number,
+                res.test_desc,
+                statusCell
+              ]
+            });
+
+          const table: ContentTable = {
+            marginBottom: 10,
+            style: 'body',
+            table: {
+              headerRows: 1,
+              widths: ['auto', '*', 'auto'],
+              body: [
+                ['Test', 'Description', 'Pass/Fail'],
+                ...rows
+              ]
+            },
+            layout: this.pdfHelpers.coloredTableHeaderLayout()
+          }
+
+          body.push([
+            {
+              style: ['tableLabelMd', 'mt-10', 'bold'],
+              text: `${test.section}. ${test.desc}`
+            },
+            table
+          ]);
+        }
+      }
     } else {
       scannedMessage = 'Unscanned';
     }
-
 
     const content = [
       this.pdfHelpers.buildSubHeader(`Security Benchmarks with kube-bench (${scannedMessage})`),
@@ -98,8 +139,4 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
 
     return content;
   }
-
-
-
-
 }

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kube-bench.service.ts
@@ -4,6 +4,7 @@ import {SecurityAuditReportPdfHelpersService} from './security-audit-report-pdf-
 import {IAuditReportSectionService} from '../interfaces/IAuditReportSectionService';
 import {ClusterObjectSummary} from '../../cluster/dto/cluster-object-summary';
 import {KubeBenchService} from '../../kube-bench/services/kube-bench.service';
+import {KubeBenchDto} from '../../kube-bench/dto/kube-bench-dto';
 
 @Injectable()
 export class SecurityAuditKubeBenchService implements IAuditReportSectionService {
@@ -28,7 +29,12 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
       kbReport?.resultsSummary?.total_warn ?? 'N/A',
     ];
 
-    return { summaryRow, content: []};
+    return {
+      summaryRow,
+      content: [
+        this.buildClusterIntro(kbReport)
+      ]
+    };
   }
 
   buildSummaryContent(summaries: TableCell[][]): Content {
@@ -58,6 +64,39 @@ export class SecurityAuditKubeBenchService implements IAuditReportSectionService
       },
       table
     ];
+  }
+
+  buildClusterIntro(report: KubeBenchDto) {
+
+    const body = [];
+    let scannedMessage = '';
+    if (report?.resultsJson) {
+      const results = report.resultsJson; // convenience
+      const total = results.Totals.total_pass + results.Totals.total_fail + results.Totals.total_warn;
+      scannedMessage = `${results.Totals.total_pass}/${total} Tests Passed`;
+
+      for (const section of results.Controls) {
+        body.push(this.pdfHelpers.buildSubHeader(`${section.text} (${section.version} v${section.detected_version})`, { level: 2, style: 'h3' } ));
+      }
+
+    } else {
+      scannedMessage = 'Unscanned';
+    }
+
+
+    const content = [
+      this.pdfHelpers.buildSubHeader(`Security Benchmarks with kube-bench (${scannedMessage})`),
+      {
+        style: 'body',
+        text: [
+          'Kube-Bench compares your cluster\'s configuration against the Center for Internet Security\'s best practices for running a Kubernetes Cluster. ',
+          'It runs as an application with elevated privileges in your cluster and then attempts to see whether the cluster is configured correctly. '
+        ]
+      },
+      body
+    ];
+
+    return content;
   }
 
 

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-kubehunter.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-kubehunter.service.ts
@@ -49,7 +49,7 @@ export class SecurityAuditKubehunterService implements IAuditReportSectionServic
       content = this.buildKubeHunterLocationTables(locations);
       summaryRow = [cluster.name, format(new Date(+report.createdAt), 'PPP'), totalHigh, totalMed, totalLow];
     } else {
-      content = { text: 'kube-hunter scan not run', style: 'italics'};
+      content = { text: 'kube-hunter scan not run', style: 'italics', marginBottom: 10 };
       summaryRow = [cluster.name, 'N/A', {text: 'No scan run', style: 'italics', colSpan: 3 },{},{}];
     }
 

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
@@ -75,6 +75,12 @@ export class SecurityAuditReportPdfHelpersService {
         color: 'red',
         marginBottom: 10
       },
+      redText: {
+        color: 'red'
+      },
+      goldText: {
+        color: '#f39c11'
+      },
       tocSub: {
         fontSize: 9,
         marginBottom: 5

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-report-pdf-helpers.service.ts
@@ -15,10 +15,10 @@ export class SecurityAuditReportPdfHelpersService {
     };
   }
 
-  buildSubHeader(title: string, options?: { skipToc?: boolean, level?: number }): Content {
+  buildSubHeader(title: string, options?: { skipToc?: boolean, level?: number, style?: string | string[] }): Content {
       return {
         text: title,
-        style: 'h2',
+        style: options?.style ? options?.style : 'h2',
         tocItem: !options?.skipToc,
         tocMargin: [options?.level ? options.level * 16 : 16, 0, 0, 0],
         tocStyle: 'tocSub',
@@ -48,6 +48,10 @@ export class SecurityAuditReportPdfHelpersService {
       },
       h2: {
         fontSize: 16,
+        marginBottom: 10
+      },
+      h3: {
+        fontSize: 12,
         marginBottom: 10
       },
       tableLabel: {

--- a/dash/backend/src/modules/security-audit-report/services/security-audit-tool-service.factory.ts
+++ b/dash/backend/src/modules/security-audit-report/services/security-audit-tool-service.factory.ts
@@ -4,6 +4,7 @@ import {SecurityAuditTrivyService} from './security-audit-trivy.service';
 import {SecurityAuditReportTools} from '../enums/security-audit-report-tools';
 import {SecurityAuditKubesecService} from './security-audit-kubesec.service';
 import {SecurityAuditKubehunterService} from './security-audit-kubehunter.service';
+import {SecurityAuditKubeBenchService} from './security-audit-kube-bench.service';
 
 @Injectable()
 export class SecurityAuditToolServiceFactory {
@@ -11,6 +12,7 @@ export class SecurityAuditToolServiceFactory {
     protected readonly trivyToolService: SecurityAuditTrivyService,
     protected readonly kubesecToolService: SecurityAuditKubesecService,
     protected readonly kubehunterToolService: SecurityAuditKubehunterService,
+    protected readonly kubebenchToolService: SecurityAuditKubeBenchService,
   ) {}
 
   getTool(tool: SecurityAuditReportTools): IAuditReportSectionService {
@@ -21,6 +23,8 @@ export class SecurityAuditToolServiceFactory {
         return this.kubesecToolService;
       case SecurityAuditReportTools.KUBEHUNTER:
         return this.kubehunterToolService;
+      case SecurityAuditReportTools.KUBEBENCH:
+        return this.kubebenchToolService;
     }
   }
 

--- a/dash/frontend/src/app/core/enum/SecurityAuditReportTools.ts
+++ b/dash/frontend/src/app/core/enum/SecurityAuditReportTools.ts
@@ -6,5 +6,6 @@
 export enum SecurityAuditReportTools {
   TRIVY = 'trivy',
   KUBESEC = 'kubesec',
-  KUBEHUNTER = 'kubehunter'
+  KUBEHUNTER = 'kubehunter',
+  KUBEBENCH = 'kubebench'
 }

--- a/dash/frontend/src/app/modules/private/pages/reports/security-audit-report/security-audit-report.component.ts
+++ b/dash/frontend/src/app/modules/private/pages/reports/security-audit-report/security-audit-report.component.ts
@@ -38,7 +38,11 @@ export class SecurityAuditReportComponent implements OnInit {
     {
       displayName: 'kube-hunter',
       value: SecurityAuditReportTools.KUBEHUNTER
-    }
+    },
+    {
+      displayName: 'kube-bench',
+      value: SecurityAuditReportTools.KUBEBENCH
+    },
   ];
 
   constructor(


### PR DESCRIPTION
Ticket 6990

Adds kube-bench as a tool that can be included in security audit reports. When enabled, the information below will be added to the summary section & cluster details sections for the tool

## Summary Section
In the summary section it has the intro paragraph followed by a table with a quick summary for all clusters
Fields in the summary table:
  - cluster name
  - Last scanned (N/A if never scanned)
  - Passed*
  - Failed*
  - Warnings*

*These cells are merged to display 'No scan run' if never scanned

## Cluster Details section
The data contained for each cluster is formatted with a header for each section (ex.  
'3. Control Plane Configuration (cis-1.7 v1.27)'). These sections appear under the main kube bench header for the cluster in the table of contents.

Within each section, a table for each test is present, containing a list of all the items covered in that test suite, and whether they are pass, fail, or warnings.


## Sample Reports
Below are some sample reports generated.
[kube-bench-everything.pdf](https://github.com/m9sweeper/m9sweeper/files/13878226/kube-bench-everything.pdf) - This file has 2 clusters that have every tool enabled. Note that one of the clusters intentionally has no scans/data for any tool to demonstrate the unscanned cases


[kube-bench-only.pdf](https://github.com/m9sweeper/m9sweeper/files/13878227/kube-bench-only.pdf) - This contains the same 2 clusters as above, but with only kube-bench data included

[kube-bench-with-data.pdf](https://github.com/m9sweeper/m9sweeper/files/13878228/kube-bench-with-data.pdf) - This only contains the kube-bench data for the cluster that has kube-bench data.


