### PR TITLE
Fix Read Only Users Can Not Download Audit Report

### DIFF
--- a/dash/backend/src/modules/reports/controllers/reports-download.controller.ts
+++ b/dash/backend/src/modules/reports/controllers/reports-download.controller.ts
@@ -20,7 +20,7 @@ export class ReportsDownloadController {
   ) {}
 
   @Get('/security-audit-report')
-  @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN)
+  @AllowedAuthorityLevels(Authority.ADMIN, Authority.SUPER_ADMIN, Authority.READ_ONLY)
   @UseGuards(AuthGuard, AuthorityGuard)
   async generatePrintableAuditReport(
     @Res({ passthrough: true }) res: Response,


### PR DESCRIPTION
How to Duplicate:
1. Log in to dev-m9sweeper as a read-only user
2. Open dev tools to the network tab, clear existing entries
3. Open the Falco page: https://dev-m9sweeper.intelletive.com/private/clusters/39/reports/security-audit-report
In the "Recent Events" card, click the "Download" button
"Report could not be generated" will display at the bottom of the page
